### PR TITLE
feat: apply switch encoding with MoE and huber loss

### DIFF
--- a/PatchTST_supervised/exp/exp_main.py
+++ b/PatchTST_supervised/exp/exp_main.py
@@ -22,6 +22,7 @@ warnings.filterwarnings('ignore')
 class Exp_Main(Exp_Basic):
     def __init__(self, args):
         super(Exp_Main, self).__init__(args)
+        self.aux_weight = getattr(args, 'aux_weight', 0.01)
 
     def _build_model(self):
         model_dict = {
@@ -48,7 +49,7 @@ class Exp_Main(Exp_Basic):
         return model_optim
 
     def _select_criterion(self):
-        criterion = nn.MSELoss()
+        criterion = nn.HuberLoss()
         return criterion
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -70,19 +71,26 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                             else:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                            aux_loss = 0.
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                         outputs = self.model(batch_x)
+                        if isinstance(outputs, tuple):
+                            outputs = outputs[0]
+                        aux_loss = 0.
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                        aux_loss = 0.
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
@@ -147,6 +155,9 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            aux_loss = 0.
+                            if isinstance(outputs, tuple):
+                                outputs, aux_loss = outputs
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -156,22 +167,25 @@ class Exp_Main(Exp_Basic):
                         f_dim = -1 if self.args.features == 'MS' else 0
                         outputs = outputs[:, -self.args.pred_len:, f_dim:]
                         batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                        loss = criterion(outputs, batch_y)
+                        loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
                         train_loss.append(loss.item())
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            aux_loss = 0.
+                            if isinstance(outputs, tuple):
+                                outputs, aux_loss = outputs
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
-                            
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark, batch_y)
+                        aux_loss = 0.
                     # print(outputs.shape,batch_y.shape)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     outputs = outputs[:, -self.args.pred_len:, f_dim:]
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                    loss = criterion(outputs, batch_y)
+                    loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
                     train_loss.append(loss.item())
 
                 if (i + 1) % 100 == 0:
@@ -247,6 +261,8 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -255,6 +271,8 @@ class Exp_Main(Exp_Basic):
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -338,6 +356,8 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -346,6 +366,8 @@ class Exp_Main(Exp_Basic):
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                         outputs = self.model(batch_x)
+                        if isinstance(outputs, tuple):
+                            outputs = outputs[0]
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]

--- a/PatchTST_supervised/layers/PatchTST_backbone.py
+++ b/PatchTST_supervised/layers/PatchTST_backbone.py
@@ -71,15 +71,15 @@ class PatchTST_backbone(nn.Module):
         z = z.permute(0,1,3,2)                                                              # z: [bs x nvars x patch_len x patch_num]
         
         # model
-        z = self.backbone(z)                                                                # z: [bs x nvars x d_model x patch_num]
-        z = self.head(z)                                                                    # z: [bs x nvars x target_window] 
+        z, aux_loss = self.backbone(z)                                                      # z: [bs x nvars x d_model x patch_num]
+        z = self.head(z)                                                                    # z: [bs x nvars x target_window]
         
         # denorm
-        if self.revin: 
+        if self.revin:
             z = z.permute(0,2,1)
             z = self.revin_layer(z, 'denorm')
             z = z.permute(0,2,1)
-        return z
+        return z, aux_loss
     
     def create_pretrain_head(self, head_nf, vars, dropout):
         return nn.Sequential(nn.Dropout(dropout),
@@ -121,10 +121,56 @@ class Flatten_Head(nn.Module):
             x = self.linear(x)
             x = self.dropout(x)
         return x
-        
-        
-    
-    
+
+
+
+class SwitchLinear(nn.Module):
+    """Switch-style linear layer with mixture of experts."""
+    def __init__(self, in_features, out_features, n_experts: int = 4):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([nn.Linear(in_features, out_features) for _ in range(n_experts)])
+        self.gate = nn.Linear(in_features, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=tuple(range(gate.dim() - 1)))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
+class SwitchFeedForward(nn.Module):
+    """MoE feed-forward layer for Switch Transformer."""
+    def __init__(self, d_model, d_ff, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(d_model, d_ff),
+                get_activation_fn(activation),
+                nn.Dropout(dropout),
+                nn.Linear(d_ff, d_model)
+            ) for _ in range(n_experts)
+        ])
+        self.gate = nn.Linear(d_model, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=(0, 1))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
 class TSTiEncoder(nn.Module):  #i means channel-independent
     def __init__(self, c_in, patch_num, patch_len, max_seq_len=1024,
                  n_layers=3, d_model=128, n_heads=16, d_k=None, d_v=None,
@@ -140,7 +186,7 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         
         # Input encoding
         q_len = patch_num
-        self.W_P = nn.Linear(patch_len, d_model)        # Eq 1: projection of feature vectors onto a d-dim vector space
+        self.W_P = SwitchLinear(patch_len, d_model)
         self.seq_len = q_len
 
         # Positional encoding
@@ -159,17 +205,17 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         n_vars = x.shape[1]
         # Input encoding
         x = x.permute(0,1,3,2)                                                   # x: [bs x nvars x patch_num x patch_len]
-        x = self.W_P(x)                                                          # x: [bs x nvars x patch_num x d_model]
+        x, aux1 = self.W_P(x)                                                    # x: [bs x nvars x patch_num x d_model]
 
         u = torch.reshape(x, (x.shape[0]*x.shape[1],x.shape[2],x.shape[3]))      # u: [bs * nvars x patch_num x d_model]
         u = self.dropout(u + self.W_pos)                                         # u: [bs * nvars x patch_num x d_model]
 
         # Encoder
-        z = self.encoder(u)                                                      # z: [bs * nvars x patch_num x d_model]
+        z, aux2 = self.encoder(u)                                                # z: [bs * nvars x patch_num x d_model]
         z = torch.reshape(z, (-1,n_vars,z.shape[-2],z.shape[-1]))                # z: [bs x nvars x patch_num x d_model]
         z = z.permute(0,1,3,2)                                                   # z: [bs x nvars x d_model x patch_num]
-        
-        return z    
+
+        return z, aux1 + aux2
             
             
     
@@ -189,12 +235,17 @@ class TSTEncoder(nn.Module):
     def forward(self, src:Tensor, key_padding_mask:Optional[Tensor]=None, attn_mask:Optional[Tensor]=None):
         output = src
         scores = None
+        aux_loss = 0.0
         if self.res_attention:
-            for mod in self.layers: output, scores = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-            return output
+            for mod in self.layers:
+                output, scores, l_aux = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
         else:
-            for mod in self.layers: output = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-            return output
+            for mod in self.layers:
+                output, l_aux = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
 
 
 
@@ -217,11 +268,8 @@ class TSTEncoderLayer(nn.Module):
         else:
             self.norm_attn = nn.LayerNorm(d_model)
 
-        # Position-wise Feed-Forward
-        self.ff = nn.Sequential(nn.Linear(d_model, d_ff, bias=bias),
-                                get_activation_fn(activation),
-                                nn.Dropout(dropout),
-                                nn.Linear(d_ff, d_model, bias=bias))
+        # Position-wise Feed-Forward replaced with MoE
+        self.ff = SwitchFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
 
         # Add & Norm
         self.dropout_ffn = nn.Dropout(dropout)
@@ -255,16 +303,16 @@ class TSTEncoderLayer(nn.Module):
         if self.pre_norm:
             src = self.norm_ffn(src)
         ## Position-wise Feed-Forward
-        src2 = self.ff(src)
+        src2, aux_loss = self.ff(src)
         ## Add & Norm
         src = src + self.dropout_ffn(src2) # Add: residual connection with residual dropout
         if not self.pre_norm:
             src = self.norm_ffn(src)
 
         if self.res_attention:
-            return src, scores
+            return src, scores, aux_loss
         else:
-            return src
+            return src, aux_loss
 
 
 

--- a/PatchTST_supervised/models/PatchTST.py
+++ b/PatchTST_supervised/models/PatchTST.py
@@ -81,12 +81,13 @@ class Model(nn.Module):
         if self.decomposition:
             res_init, trend_init = self.decomp_module(x)
             res_init, trend_init = res_init.permute(0,2,1), trend_init.permute(0,2,1)  # x: [Batch, Channel, Input length]
-            res = self.model_res(res_init)
-            trend = self.model_trend(trend_init)
+            res, aux1 = self.model_res(res_init)
+            trend, aux2 = self.model_trend(trend_init)
             x = res + trend
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
+            return x, aux1 + aux2
         else:
             x = x.permute(0,2,1)    # x: [Batch, Channel, Input length]
-            x = self.model(x)
+            x, aux = self.model(x)
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
-        return x
+            return x, aux


### PR DESCRIPTION
## Summary
- replace linear patch encoding with switch-based mixture-of-experts and swap FFN for MoE
- switch training loss to Huber and include auxiliary load-balancing term
- propagate auxiliary loss through model and training loop

## Testing
- `python -m py_compile PatchTST_supervised/layers/PatchTST_backbone.py PatchTST_supervised/models/PatchTST.py PatchTST_supervised/exp/exp_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a14874f90c8323b0a2d0bdf2a4c11d