### PR TITLE
feat: apply switch encoding with MoE and huber loss

### DIFF
--- a/PatchTST_self_supervised/patchtst_finetune.py
+++ b/PatchTST_self_supervised/patchtst_finetune.py
@@ -45,6 +45,7 @@ parser.add_argument('--head_dropout', type=float, default=0.2, help='head dropou
 # Optimization args
 parser.add_argument('--n_epochs_finetune', type=int, default=20, help='number of finetuning epochs')
 parser.add_argument('--lr', type=float, default=1e-4, help='learning rate')
+parser.add_argument('--aux_weight', type=float, default=0.01, help='weight for auxiliary load balancing loss')
 # Pretrained model name
 parser.add_argument('--pretrained_model', type=str, default=None, help='pretrained model name')
 # model id to keep track of the number of models saved
@@ -106,17 +107,18 @@ def find_lr(head_type):
     # weight_path = args.save_path + args.pretrained_model + '.pth'
     model = transfer_weights(args.pretrained_model, model)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars)] if args.revin else []
     cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
         
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=args.lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=args.lr,
                         cbs=cbs,
-                        )                        
+                        aux_weight=args.aux_weight,
+                        )
     # fit the data to the model
     suggested_lr = learn.lr_finder()
     print('suggested_lr', suggested_lr)
@@ -140,7 +142,7 @@ def finetune_func(lr=args.lr):
     # weight_path = args.pretrained_model + '.pth'
     model = transfer_weights(args.pretrained_model, model)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')   
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars, denorm=True)] if args.revin else []
     cbs += [
@@ -148,12 +150,13 @@ def finetune_func(lr=args.lr):
          SaveModelCB(monitor='valid_loss', fname=args.save_finetuned_model, path=args.save_path)
         ]
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=lr,
                         cbs=cbs,
-                        metrics=[mse]
-                        )                            
+                        metrics=[mse],
+                        aux_weight=args.aux_weight
+                        )
     # fit the data to the model
     #learn.fit_one_cycle(n_epochs=args.n_epochs_finetune, lr_max=lr)
     learn.fine_tune(n_epochs=args.n_epochs_finetune, base_lr=lr, freeze_epochs=10)
@@ -170,7 +173,7 @@ def linear_probe_func(lr=args.lr):
     # weight_path = args.save_path + args.pretrained_model + '.pth'
     model = transfer_weights(args.pretrained_model, model)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')    
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars, denorm=True)] if args.revin else []
     cbs += [
@@ -178,12 +181,13 @@ def linear_probe_func(lr=args.lr):
          SaveModelCB(monitor='valid_loss', fname=args.save_finetuned_model, path=args.save_path)
         ]
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=lr,
                         cbs=cbs,
-                        metrics=[mse]
-                        )                            
+                        metrics=[mse],
+                        aux_weight=args.aux_weight
+                        )
     # fit the data to the model
     learn.linear_probe(n_epochs=args.n_epochs_finetune, base_lr=lr)
     save_recorders(learn)
@@ -196,7 +200,7 @@ def test_func(weight_path):
     # get callbacks
     cbs = [RevInCB(dls.vars, denorm=True)] if args.revin else []
     cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
-    learn = Learner(dls, model,cbs=cbs)
+    learn = Learner(dls, model, cbs=cbs, aux_weight=args.aux_weight)
     out  = learn.test(dls.test, weight_path=weight_path+'.pth', scores=[mse,mae])         # out: a list of [pred, targ, score]
     print('score:', out[2])
     # save results

--- a/PatchTST_self_supervised/patchtst_pretrain.py
+++ b/PatchTST_self_supervised/patchtst_pretrain.py
@@ -44,6 +44,7 @@ parser.add_argument('--mask_ratio', type=float, default=0.4, help='masking ratio
 # Optimization args
 parser.add_argument('--n_epochs_pretrain', type=int, default=10, help='number of pre-training epochs')
 parser.add_argument('--lr', type=float, default=1e-4, help='learning rate')
+parser.add_argument('--aux_weight', type=float, default=0.01, help='weight for auxiliary load balancing loss')
 # model id to keep track of the number of models saved
 parser.add_argument('--pretrained_model_id', type=int, default=1, help='id of the saved pretrained model')
 parser.add_argument('--model_type', type=str, default='based_model', help='for multivariate model or univariate model')
@@ -95,17 +96,18 @@ def find_lr():
     dls = get_dls(args)    
     model = get_model(dls.vars, args)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars, denorm=False)] if args.revin else []
     cbs += [PatchMaskCB(patch_len=args.patch_len, stride=args.stride, mask_ratio=args.mask_ratio)]
         
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=args.lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=args.lr,
                         cbs=cbs,
-                        )                        
+                        aux_weight=args.aux_weight,
+                        )
     # fit the data to the model
     suggested_lr = learn.lr_finder()
     print('suggested_lr', suggested_lr)
@@ -118,7 +120,7 @@ def pretrain_func(lr=args.lr):
     # get model     
     model = get_model(dls.vars, args)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars, denorm=False)] if args.revin else []
     cbs += [
@@ -127,12 +129,13 @@ def pretrain_func(lr=args.lr):
                         path=args.save_path)
         ]
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=lr,
                         cbs=cbs,
                         #metrics=[mse]
-                        )                        
+                        aux_weight=args.aux_weight,
+                        )
     # fit the data to the model
     learn.fit_one_cycle(n_epochs=args.n_epochs_pretrain, lr_max=lr)
 

--- a/PatchTST_self_supervised/patchtst_supervised.py
+++ b/PatchTST_self_supervised/patchtst_supervised.py
@@ -44,6 +44,7 @@ parser.add_argument('--head_dropout', type=float, default=0, help='head dropout'
 # Optimization args
 parser.add_argument('--n_epochs', type=int, default=20, help='number of training epochs')
 parser.add_argument('--lr', type=float, default=1e-4, help='learning rate')
+parser.add_argument('--aux_weight', type=float, default=0.01, help='weight for auxiliary load balancing loss')
 # model id to keep track of the number of models saved
 parser.add_argument('--model_id', type=int, default=1, help='id of the saved model')
 parser.add_argument('--model_type', type=str, default='based_model', help='for multivariate model or univariate model')
@@ -91,12 +92,12 @@ def find_lr():
     dls = get_dls(args)    
     model = get_model(dls.vars, args)
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')
+    loss_func = nn.HuberLoss()
     # get callbacks
     cbs = [RevInCB(dls.vars)] if args.revin else []
     cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
     # define learner
-    learn = Learner(dls, model, loss_func, cbs=cbs)                        
+    learn = Learner(dls, model, loss_func, cbs=cbs, aux_weight=args.aux_weight)
     # fit the data to the model
     return learn.lr_finder()
 
@@ -110,7 +111,7 @@ def train_func(lr=args.lr):
     model = get_model(dls.vars, args)
 
     # get loss
-    loss_func = torch.nn.MSELoss(reduction='mean')
+    loss_func = nn.HuberLoss()
 
     # get callbacks
     cbs = [RevInCB(dls.vars)] if args.revin else []
@@ -121,11 +122,12 @@ def train_func(lr=args.lr):
         ]
 
     # define learner
-    learn = Learner(dls, model, 
-                        loss_func, 
-                        lr=lr, 
+    learn = Learner(dls, model,
+                        loss_func,
+                        lr=lr,
                         cbs=cbs,
-                        metrics=[mse]
+                        metrics=[mse],
+                        aux_weight=args.aux_weight
                         )
                         
     # fit the data to the model
@@ -141,7 +143,7 @@ def test_func():
     # get callbacks
     cbs = [RevInCB(dls.vars)] if args.revin else []
     cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
-    learn = Learner(dls, model,cbs=cbs)
+    learn = Learner(dls, model, cbs=cbs, aux_weight=args.aux_weight)
     out  = learn.test(dls.test, weight_path=weight_path, scores=[mse,mae])         # out: a list of [pred, targ, score_values]
     return out
 

--- a/PatchTST_self_supervised/src/learner.py
+++ b/PatchTST_self_supervised/src/learner.py
@@ -22,25 +22,26 @@ from unittest.mock import patch
 
 class Learner(GetAttr):
 
-    def __init__(self, dls, model, 
-                        loss_func=None, 
-                        lr=1e-3, 
-                        cbs=None, 
-                        metrics=None, 
+    def __init__(self, dls, model,
+                        loss_func=None,
+                        lr=1e-3,
+                        cbs=None,
+                        metrics=None,
                         opt_func=Adam,
                         **kwargs):
-                
+
         self.model, self.dls, self.loss_func, self.lr = model, dls, loss_func, lr
         self.opt_func = opt_func
-        #self.opt = self.opt_func(self.model.parameters(), self.lr) 
+        self.aux_weight = kwargs.get('aux_weight', 0.01)
+        #self.opt = self.opt_func(self.model.parameters(), self.lr)
         self.set_opt()
-        
+
         self.metrics = metrics
         self.n_inp  = 2
         # self.n_inp = self.dls.train.dataset.n_inp if self.dls else 0
-        # Initialize callbacks                 
-        if cbs and not isinstance(cbs, List): cbs = [cbs]    
-        self.initialize_callbacks(cbs)        
+        # Initialize callbacks
+        if cbs and not isinstance(cbs, List): cbs = [cbs]
+        self.initialize_callbacks(cbs)
         # Indicator of running lr_finder
         self.run_finder = False
 
@@ -174,8 +175,11 @@ class Learner(GetAttr):
         self.xb, self.yb = batch
         # forward
         pred = self.model_forward()
-        # compute loss
-        loss = self.loss_func(pred, self.yb)
+        if isinstance(pred, tuple):
+            pred, aux_loss = pred
+            loss = self.loss_func(pred, self.yb) + self.aux_weight * aux_loss
+        else:
+            loss = self.loss_func(pred, self.yb)
         return pred, loss
 
     def model_forward(self):
@@ -193,9 +197,12 @@ class Learner(GetAttr):
         self.xb, self.yb = batch
         # forward
         pred = self.model_forward()
-        # compute loss
-        loss = self.loss_func(pred, self.yb)
-        return pred, loss                                     
+        if isinstance(pred, tuple):
+            pred, aux_loss = pred
+            loss = self.loss_func(pred, self.yb) + self.aux_weight * aux_loss
+        else:
+            loss = self.loss_func(pred, self.yb)
+        return pred, loss
 
 
     def _do_batch_predict(self):   
@@ -206,7 +213,9 @@ class Learner(GetAttr):
         self.xb, self.yb = batch
         # forward
         pred = self.model_forward()
-        return pred 
+        if isinstance(pred, tuple):
+            pred = pred[0]
+        return pred
     
     def _do_batch_test(self):   
         self.pred, self.yb = self.test_step(self.batch)     
@@ -216,6 +225,8 @@ class Learner(GetAttr):
         self.xb, self.yb = batch
         # forward
         pred = self.model_forward()
+        if isinstance(pred, tuple):
+            pred = pred[0]
         return pred, self.yb
 
 

--- a/PatchTST_self_supervised/src/models/patchTST.py
+++ b/PatchTST_self_supervised/src/models/patchTST.py
@@ -57,17 +57,17 @@ class PatchTST(nn.Module):
             self.head = ClassificationHead(self.n_vars, d_model, target_dim, head_dropout)
 
 
-    def forward(self, z):                             
+    def forward(self, z):
         """
         z: tensor [bs x num_patch x n_vars x patch_len]
-        """   
-        z = self.backbone(z)                                                                # z: [bs x nvars x d_model x num_patch]
-        z = self.head(z)                                                                    
+        """
+        z, aux_loss = self.backbone(z)                                                     # z: [bs x nvars x d_model x num_patch]
+        z = self.head(z)
         # z: [bs x target_dim x nvars] for prediction
         #    [bs x target_dim] for regression
         #    [bs x target_dim] for classification
         #    [bs x num_patch x n_vars x patch_len] for pretrain
-        return z
+        return z, aux_loss
 
 
 class RegressionHead(nn.Module):
@@ -171,6 +171,53 @@ class PretrainHead(nn.Module):
         return x
 
 
+class SwitchLinear(nn.Module):
+    """Switch-style linear layer with mixture of experts."""
+    def __init__(self, in_features, out_features, n_experts: int = 4):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([nn.Linear(in_features, out_features) for _ in range(n_experts)])
+        self.gate = nn.Linear(in_features, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=tuple(range(gate.dim() - 1)))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
+class SwitchFeedForward(nn.Module):
+    """MoE feed-forward layer for Switch Transformer."""
+    def __init__(self, d_model, d_ff, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(d_model, d_ff),
+                get_activation_fn(activation),
+                nn.Dropout(dropout),
+                nn.Linear(d_ff, d_model)
+            ) for _ in range(n_experts)
+        ])
+        self.gate = nn.Linear(d_model, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=(0, 1))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
 class PatchTSTEncoder(nn.Module):
     def __init__(self, c_in, num_patch, patch_len, 
                  n_layers=3, d_model=128, n_heads=16, shared_embedding=True,
@@ -186,11 +233,10 @@ class PatchTSTEncoder(nn.Module):
         self.shared_embedding = shared_embedding        
 
         # Input encoding: projection of feature vectors onto a d-dim vector space
-        if not shared_embedding: 
-            self.W_P = nn.ModuleList()
-            for _ in range(self.n_vars): self.W_P.append(nn.Linear(patch_len, d_model))
+        if not shared_embedding:
+            self.W_P = nn.ModuleList([SwitchLinear(patch_len, d_model) for _ in range(self.n_vars)])
         else:
-            self.W_P = nn.Linear(patch_len, d_model)      
+            self.W_P = SwitchLinear(patch_len, d_model)
 
         # Positional encoding
         self.W_pos = positional_encoding(pe, learn_pe, num_patch, d_model)
@@ -211,23 +257,25 @@ class PatchTSTEncoder(nn.Module):
         # Input encoding
         if not self.shared_embedding:
             x_out = []
-            for i in range(n_vars): 
-                z = self.W_P[i](x[:,:,i,:])
+            aux_loss = 0.0
+            for i in range(n_vars):
+                z, aux = self.W_P[i](x[:,:,i,:])
+                aux_loss = aux_loss + aux
                 x_out.append(z)
             x = torch.stack(x_out, dim=2)
         else:
-            x = self.W_P(x)                                                      # x: [bs x num_patch x nvars x d_model]
-        x = x.transpose(1,2)                                                     # x: [bs x nvars x num_patch x d_model]        
+            x, aux_loss = self.W_P(x)                                            # x: [bs x num_patch x nvars x d_model]
+        x = x.transpose(1,2)                                                     # x: [bs x nvars x num_patch x d_model]
 
         u = torch.reshape(x, (bs*n_vars, num_patch, self.d_model) )              # u: [bs * nvars x num_patch x d_model]
         u = self.dropout(u + self.W_pos)                                         # u: [bs * nvars x num_patch x d_model]
 
         # Encoder
-        z = self.encoder(u)                                                      # z: [bs * nvars x num_patch x d_model]
+        z, aux2 = self.encoder(u)                                                # z: [bs * nvars x num_patch x d_model]
         z = torch.reshape(z, (-1,n_vars, num_patch, self.d_model))               # z: [bs x nvars x num_patch x d_model]
         z = z.permute(0,1,3,2)                                                   # z: [bs x nvars x d_model x num_patch]
 
-        return z
+        return z, aux_loss + aux2
     
     
 # Cell
@@ -249,12 +297,17 @@ class TSTEncoder(nn.Module):
         """
         output = src
         scores = None
+        aux_loss = 0.0
         if self.res_attention:
-            for mod in self.layers: output, scores = mod(output, prev=scores)
-            return output
+            for mod in self.layers:
+                output, scores, l_aux = mod(output, prev=scores)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
         else:
-            for mod in self.layers: output = mod(output)
-            return output
+            for mod in self.layers:
+                output, l_aux = mod(output)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
 
 
 
@@ -278,11 +331,8 @@ class TSTEncoderLayer(nn.Module):
         else:
             self.norm_attn = nn.LayerNorm(d_model)
 
-        # Position-wise Feed-Forward
-        self.ff = nn.Sequential(nn.Linear(d_model, d_ff, bias=bias),
-                                get_activation_fn(activation),
-                                nn.Dropout(dropout),
-                                nn.Linear(d_ff, d_model, bias=bias))
+        # Position-wise Feed-Forward replaced with MoE
+        self.ff = SwitchFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
 
         # Add & Norm
         self.dropout_ffn = nn.Dropout(dropout)
@@ -318,16 +368,16 @@ class TSTEncoderLayer(nn.Module):
         if self.pre_norm:
             src = self.norm_ffn(src)
         ## Position-wise Feed-Forward
-        src2 = self.ff(src)
+        src2, aux_loss = self.ff(src)
         ## Add & Norm
         src = src + self.dropout_ffn(src2) # Add: residual connection with residual dropout
         if not self.pre_norm:
             src = self.norm_ffn(src)
 
         if self.res_attention:
-            return src, scores
+            return src, scores, aux_loss
         else:
-            return src
+            return src, aux_loss
 
 
 

--- a/PatchTST_supervised/exp/exp_main.py
+++ b/PatchTST_supervised/exp/exp_main.py
@@ -22,6 +22,7 @@ warnings.filterwarnings('ignore')
 class Exp_Main(Exp_Basic):
     def __init__(self, args):
         super(Exp_Main, self).__init__(args)
+        self.aux_weight = getattr(args, 'aux_weight', 0.01)
 
     def _build_model(self):
         model_dict = {
@@ -48,7 +49,7 @@ class Exp_Main(Exp_Basic):
         return model_optim
 
     def _select_criterion(self):
-        criterion = nn.MSELoss()
+        criterion = nn.HuberLoss()
         return criterion
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -70,19 +71,26 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                             else:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                            aux_loss = 0.
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                         outputs = self.model(batch_x)
+                        if isinstance(outputs, tuple):
+                            outputs = outputs[0]
+                        aux_loss = 0.
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                        aux_loss = 0.
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
@@ -147,6 +155,9 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            aux_loss = 0.
+                            if isinstance(outputs, tuple):
+                                outputs, aux_loss = outputs
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -156,22 +167,25 @@ class Exp_Main(Exp_Basic):
                         f_dim = -1 if self.args.features == 'MS' else 0
                         outputs = outputs[:, -self.args.pred_len:, f_dim:]
                         batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                        loss = criterion(outputs, batch_y)
+                        loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
                         train_loss.append(loss.item())
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            aux_loss = 0.
+                            if isinstance(outputs, tuple):
+                                outputs, aux_loss = outputs
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
-                            
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark, batch_y)
+                        aux_loss = 0.
                     # print(outputs.shape,batch_y.shape)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     outputs = outputs[:, -self.args.pred_len:, f_dim:]
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                    loss = criterion(outputs, batch_y)
+                    loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
                     train_loss.append(loss.item())
 
                 if (i + 1) % 100 == 0:
@@ -247,6 +261,8 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -255,6 +271,8 @@ class Exp_Main(Exp_Basic):
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -338,6 +356,8 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
+                            if isinstance(outputs, tuple):
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -346,6 +366,8 @@ class Exp_Main(Exp_Basic):
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                         outputs = self.model(batch_x)
+                        if isinstance(outputs, tuple):
+                            outputs = outputs[0]
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]

--- a/PatchTST_supervised/layers/PatchTST_backbone.py
+++ b/PatchTST_supervised/layers/PatchTST_backbone.py
@@ -71,15 +71,15 @@ class PatchTST_backbone(nn.Module):
         z = z.permute(0,1,3,2)                                                              # z: [bs x nvars x patch_len x patch_num]
         
         # model
-        z = self.backbone(z)                                                                # z: [bs x nvars x d_model x patch_num]
-        z = self.head(z)                                                                    # z: [bs x nvars x target_window] 
+        z, aux_loss = self.backbone(z)                                                      # z: [bs x nvars x d_model x patch_num]
+        z = self.head(z)                                                                    # z: [bs x nvars x target_window]
         
         # denorm
-        if self.revin: 
+        if self.revin:
             z = z.permute(0,2,1)
             z = self.revin_layer(z, 'denorm')
             z = z.permute(0,2,1)
-        return z
+        return z, aux_loss
     
     def create_pretrain_head(self, head_nf, vars, dropout):
         return nn.Sequential(nn.Dropout(dropout),
@@ -121,10 +121,56 @@ class Flatten_Head(nn.Module):
             x = self.linear(x)
             x = self.dropout(x)
         return x
-        
-        
-    
-    
+
+
+
+class SwitchLinear(nn.Module):
+    """Switch-style linear layer with mixture of experts."""
+    def __init__(self, in_features, out_features, n_experts: int = 4):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([nn.Linear(in_features, out_features) for _ in range(n_experts)])
+        self.gate = nn.Linear(in_features, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=tuple(range(gate.dim() - 1)))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
+class SwitchFeedForward(nn.Module):
+    """MoE feed-forward layer for Switch Transformer."""
+    def __init__(self, d_model, d_ff, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
+        super().__init__()
+        self.n_experts = n_experts
+        self.experts = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(d_model, d_ff),
+                get_activation_fn(activation),
+                nn.Dropout(dropout),
+                nn.Linear(d_ff, d_model)
+            ) for _ in range(n_experts)
+        ])
+        self.gate = nn.Linear(d_model, n_experts)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate = F.softmax(gate_logits, dim=-1)
+        top1 = gate.argmax(dim=-1)
+        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
+        meangate = gate.mean(dim=(0, 1))
+        aux_loss = (meangate * self.n_experts).pow(2).mean()
+        return out, aux_loss
+
+
 class TSTiEncoder(nn.Module):  #i means channel-independent
     def __init__(self, c_in, patch_num, patch_len, max_seq_len=1024,
                  n_layers=3, d_model=128, n_heads=16, d_k=None, d_v=None,
@@ -140,7 +186,7 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         
         # Input encoding
         q_len = patch_num
-        self.W_P = nn.Linear(patch_len, d_model)        # Eq 1: projection of feature vectors onto a d-dim vector space
+        self.W_P = SwitchLinear(patch_len, d_model)
         self.seq_len = q_len
 
         # Positional encoding
@@ -159,17 +205,17 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         n_vars = x.shape[1]
         # Input encoding
         x = x.permute(0,1,3,2)                                                   # x: [bs x nvars x patch_num x patch_len]
-        x = self.W_P(x)                                                          # x: [bs x nvars x patch_num x d_model]
+        x, aux1 = self.W_P(x)                                                    # x: [bs x nvars x patch_num x d_model]
 
         u = torch.reshape(x, (x.shape[0]*x.shape[1],x.shape[2],x.shape[3]))      # u: [bs * nvars x patch_num x d_model]
         u = self.dropout(u + self.W_pos)                                         # u: [bs * nvars x patch_num x d_model]
 
         # Encoder
-        z = self.encoder(u)                                                      # z: [bs * nvars x patch_num x d_model]
+        z, aux2 = self.encoder(u)                                                # z: [bs * nvars x patch_num x d_model]
         z = torch.reshape(z, (-1,n_vars,z.shape[-2],z.shape[-1]))                # z: [bs x nvars x patch_num x d_model]
         z = z.permute(0,1,3,2)                                                   # z: [bs x nvars x d_model x patch_num]
-        
-        return z    
+
+        return z, aux1 + aux2
             
             
     
@@ -189,12 +235,17 @@ class TSTEncoder(nn.Module):
     def forward(self, src:Tensor, key_padding_mask:Optional[Tensor]=None, attn_mask:Optional[Tensor]=None):
         output = src
         scores = None
+        aux_loss = 0.0
         if self.res_attention:
-            for mod in self.layers: output, scores = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-            return output
+            for mod in self.layers:
+                output, scores, l_aux = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
         else:
-            for mod in self.layers: output = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-            return output
+            for mod in self.layers:
+                output, l_aux = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+                aux_loss = aux_loss + l_aux
+            return output, aux_loss
 
 
 
@@ -217,11 +268,8 @@ class TSTEncoderLayer(nn.Module):
         else:
             self.norm_attn = nn.LayerNorm(d_model)
 
-        # Position-wise Feed-Forward
-        self.ff = nn.Sequential(nn.Linear(d_model, d_ff, bias=bias),
-                                get_activation_fn(activation),
-                                nn.Dropout(dropout),
-                                nn.Linear(d_ff, d_model, bias=bias))
+        # Position-wise Feed-Forward replaced with MoE
+        self.ff = SwitchFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
 
         # Add & Norm
         self.dropout_ffn = nn.Dropout(dropout)
@@ -255,16 +303,16 @@ class TSTEncoderLayer(nn.Module):
         if self.pre_norm:
             src = self.norm_ffn(src)
         ## Position-wise Feed-Forward
-        src2 = self.ff(src)
+        src2, aux_loss = self.ff(src)
         ## Add & Norm
         src = src + self.dropout_ffn(src2) # Add: residual connection with residual dropout
         if not self.pre_norm:
             src = self.norm_ffn(src)
 
         if self.res_attention:
-            return src, scores
+            return src, scores, aux_loss
         else:
-            return src
+            return src, aux_loss
 
 
 

--- a/PatchTST_supervised/models/PatchTST.py
+++ b/PatchTST_supervised/models/PatchTST.py
@@ -81,12 +81,13 @@ class Model(nn.Module):
         if self.decomposition:
             res_init, trend_init = self.decomp_module(x)
             res_init, trend_init = res_init.permute(0,2,1), trend_init.permute(0,2,1)  # x: [Batch, Channel, Input length]
-            res = self.model_res(res_init)
-            trend = self.model_trend(trend_init)
+            res, aux1 = self.model_res(res_init)
+            trend, aux2 = self.model_trend(trend_init)
             x = res + trend
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
+            return x, aux1 + aux2
         else:
             x = x.permute(0,2,1)    # x: [Batch, Channel, Input length]
-            x = self.model(x)
+            x, aux = self.model(x)
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
-        return x
+            return x, aux


### PR DESCRIPTION
## Summary
- replace linear patch encoding with switch-based mixture-of-experts and swap FFN for MoE
- switch training loss to Huber and include auxiliary load-balancing term
- propagate auxiliary loss through model, learner, and training scripts

## Testing
- `python -m py_compile PatchTST_self_supervised/src/models/patchTST.py PatchTST_self_supervised/src/learner.py PatchTST_self_supervised/patchtst_pretrain.py PatchTST_self_supervised/patchtst_finetune.py PatchTST_self_supervised/patchtst_supervised.py`


------
https://chatgpt.com/codex/tasks/task_e_68a14874f90c8323b0a2d0bdf2a4c11d