### PR TITLE
Add classification dataloader and metrics for PatchTST

### DIFF
--- a/PatchTST_self_supervised/datautils.py
+++ b/PatchTST_self_supervised/datautils.py
@@ -1,196 +1,56 @@
-
-
-import numpy as np
-import pandas as pd
-import torch
-from torch import nn
-import sys
-
 from src.data.datamodule import DataLoaders
-from src.data.pred_dataset import *
+from src.data.uea_dataset import Dataset_UEA
 
-DSETS = ['ettm1', 'ettm2', 'etth1', 'etth2', 'electricity',
-         'traffic', 'illness', 'weather', 'exchange'
-        ]
+
+UEA_DATASETS = [
+    "ArticularyWordRecognition",
+    "BasicMotions",
+    "Cricket",
+    "EthanolConcentration",
+    "ERing",
+    "HandMovementDirection",
+    "Handwriting",
+    "Heartbeat",
+    "Libras",
+    "MotorImagery",
+    "NATOPS",
+    "PenDigits",
+    "PhonemeSpectra",
+    "RacketSports",
+    "SelfRegulationSCP1",
+    "SelfRegulationSCP2",
+    "SpokenArabicDigits",
+    "StandWalkJump",
+]
+
 
 def get_dls(params):
-    
-    assert params.dset in DSETS, f"Unrecognized dset (`{params.dset}`). Options include: {DSETS}"
-    if not hasattr(params,'use_time_features'): params.use_time_features = False
+    if hasattr(params, "dset") and UEA_DATASETS and params.dset not in UEA_DATASETS:
+        print(f"Warning: dataset {params.dset} not in predefined UEA list. Proceeding regardless.")
 
-    if params.dset == 'ettm1':
-        root_path = '/data/datasets/public/ETDataset/ETT-small/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_ETT_minute,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'ETTm1.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
+    dataset_kwargs = {
+        "root_path": getattr(params, "root_path", "./data/UEA"),
+        "data_path": params.dset,
+        "seq_len": getattr(params, "context_points", None),
+        "normalize": bool(getattr(params, "normalize", True)),
+        "val_ratio": getattr(params, "val_ratio", 0.1),
+        "random_seed": getattr(params, "split_seed", 42),
+    }
 
+    dls = DataLoaders(
+        datasetCls=Dataset_UEA,
+        dataset_kwargs=dataset_kwargs,
+        batch_size=params.batch_size,
+        workers=params.num_workers,
+        shuffle_train=True,
+        shuffle_val=False,
+    )
 
-    elif params.dset == 'ettm2':
-        root_path = '/data/datasets/public/ETDataset/ETT-small/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_ETT_minute,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'ETTm2.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
+    if dls.train is None:
+        raise RuntimeError("Training dataloader could not be created. Please check dataset path.")
 
-    elif params.dset == 'etth1':
-        root_path = '/data/datasets/public/ETDataset/ETT-small/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_ETT_hour,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'ETTh1.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-
-
-    elif params.dset == 'etth2':
-        root_path = '/data/datasets/public/ETDataset/ETT-small/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_ETT_hour,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'ETTh2.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-    
-
-    elif params.dset == 'electricity':
-        root_path = '/data/datasets/public/electricity/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_Custom,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'electricity.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-
-    elif params.dset == 'traffic':
-        root_path = '/data/datasets/public/traffic/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_Custom,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'traffic.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-    
-    elif params.dset == 'weather':
-        root_path = '/data/datasets/public/weather/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_Custom,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'weather.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-
-    elif params.dset == 'illness':
-        root_path = '/data/datasets/public/illness/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_Custom,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'national_illness.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-
-    elif params.dset == 'exchange':
-        root_path = '/data/datasets/public/exchange_rate/'
-        size = [params.context_points, 0, params.target_points]
-        dls = DataLoaders(
-                datasetCls=Dataset_Custom,
-                dataset_kwargs={
-                'root_path': root_path,
-                'data_path': 'exchange_rate.csv',
-                'features': params.features,
-                'scale': True,
-                'size': size,
-                'use_time_features': params.use_time_features
-                },
-                batch_size=params.batch_size,
-                workers=params.num_workers,
-                )
-    # dataset is assume to have dimension len x nvars
-    dls.vars, dls.len = dls.train.dataset[0][0].shape[1], params.context_points
-    dls.c = dls.train.dataset[0][1].shape[0]
+    train_dataset = dls.train.dataset
+    dls.vars = train_dataset.n_vars
+    dls.c = train_dataset.n_classes
+    dls.len = train_dataset.seq_len
     return dls
-
-
-
-if __name__ == "__main__":
-    class Params:
-        dset= 'etth2'
-        context_points= 384
-        target_points= 96
-        batch_size= 64
-        num_workers= 8
-        with_ray= False
-        features='M'
-    params = Params 
-    dls = get_dls(params)
-    for i, batch in enumerate(dls.valid):
-        print(i, len(batch), batch[0].shape, batch[1].shape)
-    breakpoint()

--- a/PatchTST_self_supervised/patchtst_supervised.py
+++ b/PatchTST_self_supervised/patchtst_supervised.py
@@ -1,10 +1,10 @@
 
 
-import numpy as np
-import pandas as pd
+import argparse
 import os
-import torch
-from torch import nn
+
+import numpy as np
+import torch.nn as nn
 
 from src.models.patchTST import PatchTST
 from src.learner import Learner
@@ -17,134 +17,131 @@ from src.metrics import *
 from datautils import get_dls
 
 
-import argparse
-
 parser = argparse.ArgumentParser()
 # Dataset and dataloader
-parser.add_argument('--dset', type=str, default='etth1', help='dataset name')
-parser.add_argument('--context_points', type=int, default=336, help='sequence length')
-parser.add_argument('--target_points', type=int, default=96, help='forecast horizon')
+parser.add_argument('--dset', type=str, default='HandMovementDirection', help='UEA dataset name')
+parser.add_argument('--root_path', type=str, default='./data/UEA', help='root directory of the dataset archive')
+parser.add_argument('--context_points', type=int, default=512, help='sequence length (after padding/cropping)')
 parser.add_argument('--batch_size', type=int, default=64, help='batch size')
 parser.add_argument('--num_workers', type=int, default=1, help='number of workers for DataLoader')
-parser.add_argument('--scaler', type=str, default='standard', help='scale the input data')
-parser.add_argument('--features', type=str, default='M', help='for multivariate model or univariate model')
-parser.add_argument('--use_time_features', type=int, default=0, help='whether to use time features or not')
+parser.add_argument('--val_ratio', type=float, default=0.1, help='ratio of the training split used for validation')
+parser.add_argument('--normalize', type=int, default=1, help='if true, apply per-sample z-normalization')
+parser.add_argument('--split_seed', type=int, default=42, help='random seed for the train/val split')
 # Patch
-parser.add_argument('--patch_len', type=int, default=32, help='patch length')
-parser.add_argument('--stride', type=int, default=16, help='stride between patch')
+parser.add_argument('--patch_len', type=int, default=16, help='patch length')
+parser.add_argument('--stride', type=int, default=8, help='stride between patches')
 # RevIN
-parser.add_argument('--revin', type=int, default=1, help='reversible instance normalization')
+parser.add_argument('--revin', type=int, default=0, help='reversible instance normalization (input only)')
 # Model args
 parser.add_argument('--n_layers', type=int, default=3, help='number of Transformer layers')
 parser.add_argument('--n_heads', type=int, default=16, help='number of Transformer heads')
 parser.add_argument('--d_model', type=int, default=128, help='Transformer d_model')
-parser.add_argument('--d_ff', type=int, default=256, help='Tranformer MLP dimension')
+parser.add_argument('--d_ff', type=int, default=256, help='Transformer MLP dimension')
 parser.add_argument('--dropout', type=float, default=0.2, help='Transformer dropout')
-parser.add_argument('--head_dropout', type=float, default=0, help='head dropout')
+parser.add_argument('--head_dropout', type=float, default=0.1, help='head dropout')
 # Optimization args
 parser.add_argument('--n_epochs', type=int, default=20, help='number of training epochs')
 parser.add_argument('--lr', type=float, default=1e-4, help='learning rate')
 parser.add_argument('--aux_weight', type=float, default=0.01, help='weight for auxiliary load balancing loss')
 # model id to keep track of the number of models saved
 parser.add_argument('--model_id', type=int, default=1, help='id of the saved model')
-parser.add_argument('--model_type', type=str, default='based_model', help='for multivariate model or univariate model')
+parser.add_argument('--model_type', type=str, default='classification', help='sub-folder used for checkpoints')
 # training
 parser.add_argument('--is_train', type=int, default=1, help='training the model')
 
 
 args = parser.parse_args()
 print('args:', args)
-args.save_model_name = 'patchtst_supervised'+'_cw'+str(args.context_points)+'_tw'+str(args.target_points) + '_patch'+str(args.patch_len) + '_stride'+str(args.stride)+'_epochs'+str(args.n_epochs) + '_model' + str(args.model_id)
-args.save_path = 'saved_models/' + args.dset + '/patchtst_supervised/' + args.model_type + '/'
-if not os.path.exists(args.save_path): os.makedirs(args.save_path)
+args.save_model_name = (
+    'patchtst_classification'
+    + f"_{args.dset}_sl{args.context_points}_patch{args.patch_len}_stride{args.stride}_epochs{args.n_epochs}_model{args.model_id}"
+)
+args.save_path = f"saved_models/{args.dset}/patchtst_classification/{args.model_type}/"
+os.makedirs(args.save_path, exist_ok=True)
 
 
-def get_model(c_in, args):
+def get_model(c_in, n_classes, args):
     """
     c_in: number of input variables
     """
-    # get number of patches
-    num_patch = (max(args.context_points, args.patch_len)-args.patch_len) // args.stride + 1    
+    num_patch = (max(args.context_points, args.patch_len) - args.patch_len) // args.stride + 1
     print('number of patches:', num_patch)
-    
-    # get model
-    model = PatchTST(c_in=c_in,
-                target_dim=args.target_points,
-                patch_len=args.patch_len,
-                stride=args.stride,
-                num_patch=num_patch,                
-                n_layers=args.n_layers,
-                n_heads=args.n_heads,
-                d_model=args.d_model,
-                shared_embedding=True,
-                d_ff=args.d_ff,                        
-                dropout=args.dropout,
-                head_dropout=args.head_dropout,
-                act='relu',
-                head_type='prediction',
-                res_attention=False
-                )    
+
+    model = PatchTST(
+        c_in=c_in,
+        target_dim=n_classes,
+        patch_len=args.patch_len,
+        stride=args.stride,
+        num_patch=num_patch,
+        n_layers=args.n_layers,
+        n_heads=args.n_heads,
+        d_model=args.d_model,
+        shared_embedding=True,
+        d_ff=args.d_ff,
+        dropout=args.dropout,
+        head_dropout=args.head_dropout,
+        act='relu',
+        head_type='classification',
+        res_attention=False,
+    )
     return model
 
 
+def _default_cbs(dls):
+    cbs = []
+    if args.revin:
+        cbs.append(RevInCB(dls.vars, denorm=False))
+    cbs.append(PatchCB(patch_len=args.patch_len, stride=args.stride))
+    return cbs
+
+
 def find_lr():
-    # get dataloader
-    dls = get_dls(args)    
-    model = get_model(dls.vars, args)
-    # get loss
-    loss_func = nn.HuberLoss()
-    # get callbacks
-    cbs = [RevInCB(dls.vars)] if args.revin else []
-    cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
-    # define learner
-    learn = Learner(dls, model, loss_func, cbs=cbs, aux_weight=args.aux_weight)
-    # fit the data to the model
+    dls = get_dls(args)
+    model = get_model(dls.vars, dls.c, args)
+    loss_func = nn.CrossEntropyLoss()
+    learn = Learner(dls, model, loss_func, cbs=_default_cbs(dls), aux_weight=args.aux_weight)
     return learn.lr_finder()
 
 
 def train_func(lr=args.lr):
-    # get dataloader
     dls = get_dls(args)
     print('in out', dls.vars, dls.c, dls.len)
-    
-    # get model
-    model = get_model(dls.vars, args)
 
-    # get loss
-    loss_func = nn.HuberLoss()
+    model = get_model(dls.vars, dls.c, args)
 
-    # get callbacks
-    cbs = [RevInCB(dls.vars)] if args.revin else []
-    cbs += [
-         PatchCB(patch_len=args.patch_len, stride=args.stride),
-         SaveModelCB(monitor='valid_loss', fname=args.save_model_name, 
-                     path=args.save_path )
-        ]
+    loss_func = nn.CrossEntropyLoss()
 
-    # define learner
-    learn = Learner(dls, model,
-                        loss_func,
-                        lr=lr,
-                        cbs=cbs,
-                        metrics=[mse],
-                        aux_weight=args.aux_weight
-                        )
-                        
-    # fit the data to the model
+    cbs = _default_cbs(dls)
+    monitor_metric = 'valid_accuracy' if dls.valid else 'train_loss'
+    comp_fn = np.less if monitor_metric == 'train_loss' else np.greater
+    cbs.append(
+        SaveModelCB(
+            monitor=monitor_metric,
+            fname=args.save_model_name,
+            path=args.save_path,
+            comp=comp_fn,
+        )
+    )
+
+    learn = Learner(
+        dls,
+        model,
+        loss_func,
+        lr=lr,
+        cbs=cbs,
+        metrics=[accuracy],
+        aux_weight=args.aux_weight,
+    )
+
     learn.fit_one_cycle(n_epochs=args.n_epochs, lr_max=lr, pct_start=0.2)
 
 
 def test_func():
     weight_path = args.save_path + args.save_model_name + '.pth'
-    # get dataloader
     dls = get_dls(args)
-    model = get_model(dls.vars, args)
-    #model = torch.load(weight_path)
-    # get callbacks
-    cbs = [RevInCB(dls.vars)] if args.revin else []
-    cbs += [PatchCB(patch_len=args.patch_len, stride=args.stride)]
-    learn = Learner(dls, model, cbs=cbs, aux_weight=args.aux_weight)
-    out  = learn.test(dls.test, weight_path=weight_path, scores=[mse,mae])         # out: a list of [pred, targ, score_values]
+    model = get_model(dls.vars, dls.c, args)
+    learn = Learner(dls, model, cbs=_default_cbs(dls), aux_weight=args.aux_weight)
+    out = learn.test(dls.test, weight_path=weight_path, scores=[accuracy])
     return out
 
 

--- a/PatchTST_self_supervised/src/data/datamodule.py
+++ b/PatchTST_self_supervised/src/data/datamodule.py
@@ -1,7 +1,7 @@
 import warnings
 
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 
 class DataLoaders:

--- a/PatchTST_self_supervised/src/data/uea_dataset.py
+++ b/PatchTST_self_supervised/src/data/uea_dataset.py
@@ -1,0 +1,217 @@
+import os
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+import torch
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder
+from torch.utils.data import Dataset
+
+
+class Dataset_UEA(Dataset):
+    """Time-series classification dataset loader for UEA style archives."""
+
+    _CACHE: Dict[Tuple[str, str, int, bool, float, int], Dict] = {}
+
+    def __init__(
+        self,
+        root_path: str,
+        data_path: str,
+        split: str = "train",
+        seq_len: int = None,
+        normalize: bool = True,
+        val_ratio: float = 0.1,
+        random_seed: int = 42,
+    ):
+        super().__init__()
+        split = split.lower()
+        cache_key = (
+            os.path.abspath(root_path),
+            data_path,
+            -1 if seq_len is None else int(seq_len),
+            bool(normalize),
+            float(val_ratio),
+            int(random_seed),
+        )
+        if cache_key not in Dataset_UEA._CACHE:
+            Dataset_UEA._CACHE[cache_key] = self._prepare_splits(
+                root_path=root_path,
+                data_path=data_path,
+                seq_len=seq_len,
+                normalize=normalize,
+                val_ratio=val_ratio,
+                random_seed=random_seed,
+            )
+        cache = Dataset_UEA._CACHE[cache_key]
+        if split not in cache["splits"]:
+            raise ValueError(f"Unknown split '{split}'. Available: {list(cache['splits'].keys())}")
+        tensors = cache["splits"][split]
+        self.data = tensors["data"]
+        self.targets = tensors["labels"]
+        self.seq_len = cache["meta"]["seq_len"]
+        self.n_vars = cache["meta"]["n_vars"]
+        self.n_classes = cache["meta"]["n_classes"]
+        self.n_inp = 1
+
+    def __len__(self):
+        return self.data.shape[0]
+
+    def __getitem__(self, idx):
+        return self.data[idx], self.targets[idx]
+
+    @classmethod
+    def _prepare_splits(cls, root_path, data_path, seq_len, normalize, val_ratio, random_seed):
+        train_x, train_y, test_x, test_y = cls._load_raw_arrays(root_path, data_path)
+        train_x = cls._format_batch(train_x)
+        test_x = cls._format_batch(test_x)
+        train_y = cls._reshape_labels(train_y)
+        test_y = cls._reshape_labels(test_y)
+
+        label_encoder = LabelEncoder()
+        label_encoder.fit(np.concatenate([train_y, test_y], axis=0))
+        train_y = label_encoder.transform(train_y)
+        test_y = label_encoder.transform(test_y)
+
+        if normalize:
+            train_x = cls._normalize_per_sample(train_x)
+            test_x = cls._normalize_per_sample(test_x)
+
+        if seq_len is None:
+            seq_len = int(max(train_x.shape[1], test_x.shape[1]))
+        train_x = cls._resize_batch(train_x, seq_len)
+        test_x = cls._resize_batch(test_x, seq_len)
+
+        if val_ratio > 0:
+            val_ratio = min(max(val_ratio, 1e-6), 0.5)
+            stratify = train_y if len(np.unique(train_y)) > 1 else None
+            train_x, val_x, train_y, val_y = train_test_split(
+                train_x,
+                train_y,
+                test_size=val_ratio,
+                random_state=random_seed,
+                stratify=stratify,
+            )
+        else:
+            val_x = np.empty((0, seq_len, train_x.shape[2]), dtype=train_x.dtype)
+            val_y = np.empty((0,), dtype=train_y.dtype)
+
+        meta = {"seq_len": seq_len, "n_vars": train_x.shape[2], "n_classes": len(label_encoder.classes_)}
+        splits = {
+            "train": cls._to_tensors(train_x, train_y),
+            "val": cls._to_tensors(val_x, val_y),
+            "test": cls._to_tensors(test_x, test_y),
+        }
+        return {"splits": splits, "meta": meta}
+
+    @staticmethod
+    def _to_tensors(data, labels):
+        data = data.astype(np.float32, copy=False)
+        labels = labels.astype(np.int64, copy=False)
+        return {
+            "data": torch.from_numpy(data),
+            "labels": torch.from_numpy(labels),
+        }
+
+    @staticmethod
+    def _reshape_labels(labels):
+        labels = np.asarray(labels)
+        if labels.ndim > 1:
+            labels = labels.squeeze()
+        return labels
+
+    @staticmethod
+    def _format_batch(data):
+        data = np.asarray(data)
+        if data.ndim == 2:
+            data = data[:, :, None]
+        if data.ndim != 3:
+            raise ValueError(f"Expected 3D array (samples, length, channels), got shape {data.shape}")
+        # ensure layout [N, L, C]
+        if data.shape[1] < data.shape[2]:
+            data = np.transpose(data, (0, 2, 1))
+        return data
+
+    @staticmethod
+    def _normalize_per_sample(data):
+        mean = data.mean(axis=1, keepdims=True)
+        std = data.std(axis=1, keepdims=True)
+        std[std < 1e-5] = 1.0
+        return (data - mean) / std
+
+    @staticmethod
+    def _resize_batch(data, target_len):
+        if data.shape[1] == target_len:
+            return data
+        if data.shape[1] > target_len:
+            return data[:, -target_len:, :]
+        pad_len = target_len - data.shape[1]
+        pad = np.zeros((data.shape[0], pad_len, data.shape[2]), dtype=data.dtype)
+        return np.concatenate([pad, data], axis=1)
+
+    @classmethod
+    def _load_raw_arrays(cls, root_path, data_path):
+        root = Path(root_path).expanduser()
+        base = root / data_path
+        if base.is_file():
+            return cls._read_combined_file(base)
+        if base.with_suffix(".npz").is_file():
+            return cls._read_combined_file(base.with_suffix(".npz"))
+        if base.is_dir():
+            combined = base / f"{base.name}.npz"
+            if combined.is_file():
+                return cls._read_combined_file(combined)
+            train_file = base / "train.npz"
+            test_file = base / "test.npz"
+            if train_file.is_file() and test_file.is_file():
+                return cls._read_split_files(train_file, test_file)
+            upper_train = base / f"{base.name}_TRAIN.npz"
+            upper_test = base / f"{base.name}_TEST.npz"
+            if upper_train.is_file() and upper_test.is_file():
+                return cls._read_split_files(upper_train, upper_test)
+        # fall back to parent directory based matches
+        stem = base.name if base.is_dir() else base.stem
+        parent = base.parent
+        if parent is None or not parent.exists():
+            parent = root
+        train_candidates = [
+            parent / f"{stem}_train.npz",
+            parent / f"{stem}_TRAIN.npz",
+        ]
+        test_candidates = [
+            parent / f"{stem}_test.npz",
+            parent / f"{stem}_TEST.npz",
+        ]
+        for t_file, v_file in zip(train_candidates, test_candidates):
+            if t_file.is_file() and v_file.is_file():
+                return cls._read_split_files(t_file, v_file)
+        raise FileNotFoundError(
+            f"Could not locate dataset '{data_path}' under '{root_path}'. "
+            "Expected either a combined NPZ file or train/test NPZ pairs."
+        )
+
+    @staticmethod
+    def _read_combined_file(path):
+        with np.load(path, allow_pickle=True) as handler:
+            train_x = Dataset_UEA._extract_array(handler, ["X_train", "x_train", "train_x", "trainX", "train"])
+            train_y = Dataset_UEA._extract_array(handler, ["y_train", "Y_train", "train_y", "trainY", "label_train"])
+            test_x = Dataset_UEA._extract_array(handler, ["X_test", "x_test", "test_x", "testX", "test"])
+            test_y = Dataset_UEA._extract_array(handler, ["y_test", "Y_test", "test_y", "testY", "label_test"])
+        return train_x, train_y, test_x, test_y
+
+    @staticmethod
+    def _read_split_files(train_file, test_file):
+        with np.load(train_file, allow_pickle=True) as train_handler:
+            train_x = Dataset_UEA._extract_array(train_handler, ["x", "X", "data", "samples"])
+            train_y = Dataset_UEA._extract_array(train_handler, ["y", "Y", "labels", "target"])
+        with np.load(test_file, allow_pickle=True) as test_handler:
+            test_x = Dataset_UEA._extract_array(test_handler, ["x", "X", "data", "samples"])
+            test_y = Dataset_UEA._extract_array(test_handler, ["y", "Y", "labels", "target"])
+        return train_x, train_y, test_x, test_y
+
+    @staticmethod
+    def _extract_array(handler, keys):
+        for key in keys:
+            if key in handler:
+                return handler[key]
+        raise ValueError(f"None of the keys {keys} found in NPZ file {list(handler.keys())}")

--- a/PatchTST_self_supervised/src/metrics.py
+++ b/PatchTST_self_supervised/src/metrics.py
@@ -19,3 +19,11 @@ def r2_score(y_true, y_pred):
 def mape(y_true, y_pred):
     from sklearn.metrics import mean_absolute_percentage_error
     return mean_absolute_percentage_error(y_true, y_pred)
+
+
+def accuracy(y_true: Tensor, y_pred: Tensor):
+    """Classification accuracy."""
+    if y_true.ndim > 1:
+        y_true = y_true.argmax(dim=-1)
+    preds = y_pred.argmax(dim=-1)
+    return (preds == y_true).float().mean()


### PR DESCRIPTION
## Summary
- add a dedicated UEA dataset loader that pads/normalizes classification data and expose metadata for the learner
- rework the PatchTST supervised script and data utils to use the classification dataset, CrossEntropy loss, and accuracy metric
- add an accuracy helper metric and import fixes so the classification training/evaluation loop can track accuracy and save the best checkpoint

## Testing
- `python -m compileall PatchTST_self_supervised/src/data/uea_dataset.py PatchTST_self_supervised/patchtst_supervised.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d586b24388323a4a605d23ef09cc3)