### PR TITLE
Add volatility adaptive Huber loss to PatchTST

### DIFF
--- a/PatchTST_supervised/exp/exp_main.py
+++ b/PatchTST_supervised/exp/exp_main.py
@@ -6,9 +6,9 @@ from utils.metrics import metric
 
 import numpy as np
 import torch
-import torch.nn as nn
 from torch import optim
-from torch.optim import lr_scheduler 
+from torch.optim import lr_scheduler
+import torch.nn as nn
 
 import os
 import time
@@ -16,6 +16,8 @@ import time
 import warnings
 import matplotlib.pyplot as plt
 import numpy as np
+
+from utils.losses import NoiseAdaptiveHybridHuber
 
 warnings.filterwarnings('ignore')
 
@@ -49,7 +51,7 @@ class Exp_Main(Exp_Basic):
         return model_optim
 
     def _select_criterion(self):
-        criterion = nn.HuberLoss()
+        criterion = NoiseAdaptiveHybridHuber(delta=self.args.vah_delta, gamma=self.args.vah_gamma)
         return criterion
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -98,7 +100,7 @@ class Exp_Main(Exp_Basic):
                 pred = outputs.detach().cpu()
                 true = batch_y.detach().cpu()
 
-                loss = criterion(pred, true)
+                loss = criterion(pred, true, x_for_volatility=true)
 
                 total_loss.append(loss)
         total_loss = np.average(total_loss)
@@ -167,7 +169,7 @@ class Exp_Main(Exp_Basic):
                         f_dim = -1 if self.args.features == 'MS' else 0
                         outputs = outputs[:, -self.args.pred_len:, f_dim:]
                         batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                        loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
+                        loss = criterion(outputs, batch_y, x_for_volatility=batch_y) + self.aux_weight * aux_loss
                         train_loss.append(loss.item())
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
@@ -185,7 +187,7 @@ class Exp_Main(Exp_Basic):
                     f_dim = -1 if self.args.features == 'MS' else 0
                     outputs = outputs[:, -self.args.pred_len:, f_dim:]
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                    loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
+                    loss = criterion(outputs, batch_y, x_for_volatility=batch_y) + self.aux_weight * aux_loss
                     train_loss.append(loss.item())
 
                 if (i + 1) % 100 == 0:

--- a/PatchTST_supervised/run_longExp.py
+++ b/PatchTST_supervised/run_longExp.py
@@ -81,6 +81,8 @@ if __name__ == '__main__':
     parser.add_argument('--learning_rate', type=float, default=0.0001, help='optimizer learning rate')
     parser.add_argument('--des', type=str, default='test', help='exp description')
     parser.add_argument('--loss', type=str, default='mse', help='loss function')
+    parser.add_argument('--vah_delta', type=float, default=1.0, help='delta for volatility-adaptive Huber loss')
+    parser.add_argument('--vah_gamma', type=float, default=1.0, help='gamma for volatility-adaptive Huber loss')
     parser.add_argument('--lradj', type=str, default='type3', help='adjust learning rate')
     parser.add_argument('--pct_start', type=float, default=0.3, help='pct_start')
     parser.add_argument('--use_amp', action='store_true', help='use automatic mixed precision training', default=False)

--- a/PatchTST_supervised/utils/losses.py
+++ b/PatchTST_supervised/utils/losses.py
@@ -1,0 +1,44 @@
+import torch
+import torch.nn as nn
+
+
+def huber_loss(residual, delta=1.0):
+    abs_res = residual.abs()
+    quadratic = 0.5 * abs_res ** 2
+    linear = delta * (abs_res - 0.5 * delta)
+    return torch.where(abs_res <= delta, quadratic, linear)
+
+
+class NoiseAdaptiveHybridHuber(nn.Module):
+    def __init__(self, delta=1.0, gamma=1.0, eps=1e-6):
+        super().__init__()
+        self.delta = delta
+        self.gamma = gamma
+        self.eps = eps
+
+    def forward(self, y_pred, y_true, x_for_volatility=None):
+        """
+        Args:
+            y_pred, y_true: tensors shaped [B, L, C]
+            x_for_volatility: optional tensor used to estimate per-sample volatility
+                               Accepts shapes [B, L, C], [B, L], or [B, C].
+                               Defaults to ``y_true`` when not provided.
+        """
+        if x_for_volatility is None:
+            x_for_volatility = y_true
+
+        B = x_for_volatility.size(0)
+        std_per_sample = x_for_volatility.view(B, -1).std(dim=1)
+
+        s_ref = std_per_sample.mean().detach() + self.eps
+        rel_std = std_per_sample / s_ref
+
+        w = 1.0 / (1.0 + self.gamma * rel_std)
+        w = w.view(B, 1, 1)
+
+        residual = y_pred - y_true
+        mse_term = 0.5 * residual ** 2
+        huber_term = huber_loss(residual, delta=self.delta)
+
+        loss = w * mse_term + (1.0 - w) * huber_term
+        return loss.mean()


### PR DESCRIPTION
## Summary
- add a volatility-adaptive hybrid Huber loss implementation for supervised PatchTST runs
- integrate the new loss into training and validation with optional delta and gamma arguments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ecad982108323bae8ec63a0ae3733)