### PR TITLE
Add MoE configuration toggles for PatchTST

### DIFF
--- a/PatchTST_supervised/layers/PatchTST_backbone.py
+++ b/PatchTST_supervised/layers/PatchTST_backbone.py
@@ -20,7 +20,8 @@ class PatchTST_backbone(nn.Module):
                  padding_var:Optional[int]=None, attn_mask:Optional[Tensor]=None, res_attention:bool=True, pre_norm:bool=False, store_attn:bool=False,
                  pe:str='zeros', learn_pe:bool=True, fc_dropout:float=0., head_dropout = 0, padding_patch = None,
                  pretrain_head:bool=False, head_type = 'flatten', individual = False, revin = True, affine = True, subtract_last = False,
-                 verbose:bool=False, **kwargs):
+                 verbose:bool=False, use_value_moe: bool = True, use_ffn_moe: bool = True,
+                 value_moe_experts: int = 4, ffn_moe_experts: int = 4, **kwargs):
         
         super().__init__()
         
@@ -37,12 +38,13 @@ class PatchTST_backbone(nn.Module):
             self.padding_patch_layer = nn.ReplicationPad1d((0, stride)) 
             patch_num += 1
         
-        # Backbone 
+        # Backbone
         self.backbone = TSTiEncoder(c_in, patch_num=patch_num, patch_len=patch_len, max_seq_len=max_seq_len,
                                 n_layers=n_layers, d_model=d_model, n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff,
                                 attn_dropout=attn_dropout, dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var,
                                 attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
-                                pe=pe, learn_pe=learn_pe, verbose=verbose, **kwargs)
+                                pe=pe, learn_pe=learn_pe, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe,
+                                value_moe_experts=value_moe_experts, ffn_moe_experts=ffn_moe_experts, **kwargs)
 
         # Head
         self.head_nf = d_model * patch_num
@@ -144,6 +146,26 @@ class SwitchLinear(nn.Module):
         return out, aux_loss
 
 
+class LinearValueEncoder(nn.Module):
+    """Standard linear projection used when value-side MoE is disabled."""
+
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+
+    def forward(self, x):
+        out = self.linear(x)
+        aux_loss = torch.zeros((), device=x.device, dtype=x.dtype)
+        return out, aux_loss
+
+
+def build_value_encoder(use_value_moe: bool, in_features: int, out_features: int, n_experts: int = 4):
+    """Factory that builds either SwitchLinear or a plain Linear layer."""
+    if use_value_moe:
+        return SwitchLinear(in_features, out_features, n_experts=n_experts)
+    return LinearValueEncoder(in_features, out_features)
+
+
 class SwitchFeedForward(nn.Module):
     """MoE feed-forward layer for Switch Transformer."""
     def __init__(self, d_model, d_ff, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
@@ -171,22 +193,49 @@ class SwitchFeedForward(nn.Module):
         return out, aux_loss
 
 
+class StandardFeedForward(nn.Module):
+    """Standard position-wise feed-forward network used when MoE is disabled."""
+
+    def __init__(self, d_model, d_ff, dropout: float = 0., activation: str = "gelu"):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(d_model, d_ff),
+            get_activation_fn(activation),
+            nn.Dropout(dropout),
+            nn.Linear(d_ff, d_model),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x):
+        out = self.net(x)
+        aux_loss = torch.zeros((), device=x.device, dtype=x.dtype)
+        return out, aux_loss
+
+
+def build_ffn_layer(use_ffn_moe: bool, d_model: int, d_ff: int, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
+    """Factory that builds either SwitchFeedForward or a standard FFN."""
+    if use_ffn_moe:
+        return SwitchFeedForward(d_model, d_ff, n_experts=n_experts, dropout=dropout, activation=activation)
+    return StandardFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
+
+
 class TSTiEncoder(nn.Module):  #i means channel-independent
     def __init__(self, c_in, patch_num, patch_len, max_seq_len=1024,
                  n_layers=3, d_model=128, n_heads=16, d_k=None, d_v=None,
                  d_ff=256, norm='BatchNorm', attn_dropout=0., dropout=0., act="gelu", store_attn=False,
                  key_padding_mask='auto', padding_var=None, attn_mask=None, res_attention=True, pre_norm=False,
-                 pe='zeros', learn_pe=True, verbose=False, **kwargs):
+                 pe='zeros', learn_pe=True, verbose=False, use_value_moe: bool = True, use_ffn_moe: bool = True,
+                 value_moe_experts: int = 4, ffn_moe_experts: int = 4, **kwargs):
         
         
         super().__init__()
         
         self.patch_num = patch_num
         self.patch_len = patch_len
-        
+
         # Input encoding
         q_len = patch_num
-        self.W_P = SwitchLinear(patch_len, d_model)
+        self.W_P = build_value_encoder(use_value_moe, patch_len, d_model, n_experts=value_moe_experts)
         self.seq_len = q_len
 
         # Positional encoding
@@ -197,7 +246,8 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
 
         # Encoder
         self.encoder = TSTEncoder(q_len, d_model, n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout, dropout=dropout,
-                                   pre_norm=pre_norm, activation=act, res_attention=res_attention, n_layers=n_layers, store_attn=store_attn)
+                                   pre_norm=pre_norm, activation=act, res_attention=res_attention, n_layers=n_layers,
+                                   store_attn=store_attn, use_ffn_moe=use_ffn_moe, ffn_moe_experts=ffn_moe_experts)
 
         
     def forward(self, x) -> Tensor:                                              # x: [bs x nvars x patch_len x patch_num]
@@ -221,15 +271,17 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
     
 # Cell
 class TSTEncoder(nn.Module):
-    def __init__(self, q_len, d_model, n_heads, d_k=None, d_v=None, d_ff=None, 
+    def __init__(self, q_len, d_model, n_heads, d_k=None, d_v=None, d_ff=None,
                         norm='BatchNorm', attn_dropout=0., dropout=0., activation='gelu',
-                        res_attention=False, n_layers=1, pre_norm=False, store_attn=False):
+                        res_attention=False, n_layers=1, pre_norm=False, store_attn=False,
+                        use_ffn_moe: bool = True, ffn_moe_experts: int = 4):
         super().__init__()
 
         self.layers = nn.ModuleList([TSTEncoderLayer(q_len, d_model, n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm,
                                                       attn_dropout=attn_dropout, dropout=dropout,
                                                       activation=activation, res_attention=res_attention,
-                                                      pre_norm=pre_norm, store_attn=store_attn) for i in range(n_layers)])
+                                                      pre_norm=pre_norm, store_attn=store_attn,
+                                                      use_ffn_moe=use_ffn_moe, ffn_moe_experts=ffn_moe_experts) for i in range(n_layers)])
         self.res_attention = res_attention
 
     def forward(self, src:Tensor, key_padding_mask:Optional[Tensor]=None, attn_mask:Optional[Tensor]=None):
@@ -251,7 +303,8 @@ class TSTEncoder(nn.Module):
 
 class TSTEncoderLayer(nn.Module):
     def __init__(self, q_len, d_model, n_heads, d_k=None, d_v=None, d_ff=256, store_attn=False,
-                 norm='BatchNorm', attn_dropout=0, dropout=0., bias=True, activation="gelu", res_attention=False, pre_norm=False):
+                 norm='BatchNorm', attn_dropout=0, dropout=0., bias=True, activation="gelu", res_attention=False, pre_norm=False,
+                 use_ffn_moe: bool = True, ffn_moe_experts: int = 4):
         super().__init__()
         assert not d_model%n_heads, f"d_model ({d_model}) must be divisible by n_heads ({n_heads})"
         d_k = d_model // n_heads if d_k is None else d_k
@@ -269,7 +322,7 @@ class TSTEncoderLayer(nn.Module):
             self.norm_attn = nn.LayerNorm(d_model)
 
         # Position-wise Feed-Forward replaced with MoE
-        self.ff = SwitchFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
+        self.ff = build_ffn_layer(use_ffn_moe, d_model, d_ff, n_experts=ffn_moe_experts, dropout=dropout, activation=activation)
 
         # Add & Norm
         self.dropout_ffn = nn.Dropout(dropout)

--- a/PatchTST_supervised/models/PatchTST.py
+++ b/PatchTST_supervised/models/PatchTST.py
@@ -44,37 +44,59 @@ class Model(nn.Module):
         
         decomposition = configs.decomposition
         kernel_size = configs.kernel_size
+
+        moe_mode = getattr(configs, 'moe_mode', None)
+        use_value_moe_arg = getattr(configs, 'use_value_moe', None)
+        use_ffn_moe_arg = getattr(configs, 'use_ffn_moe', None)
+
+        if moe_mode is None:
+            use_value_moe = True if use_value_moe_arg is None else bool(use_value_moe_arg)
+            use_ffn_moe = True if use_ffn_moe_arg is None else bool(use_ffn_moe_arg)
+            if use_value_moe and use_ffn_moe:
+                moe_mode = 'both'
+            elif use_value_moe and not use_ffn_moe:
+                moe_mode = 'value'
+            elif not use_value_moe and use_ffn_moe:
+                moe_mode = 'ffn'
+            else:
+                moe_mode = 'none'
+        else:
+            moe_mode = moe_mode.lower()
+            use_value_moe = moe_mode in ['value', 'both']
+            use_ffn_moe = moe_mode in ['ffn', 'both']
+
+        print(f"MoE config: moe_mode={moe_mode}, use_value_moe={use_value_moe}, use_ffn_moe={use_ffn_moe}")
         
         
         # model
         self.decomposition = decomposition
         if self.decomposition:
             self.decomp_module = series_decomp(kernel_size)
-            self.model_trend = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride, 
+            self.model_trend = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride,
                                   max_seq_len=max_seq_len, n_layers=n_layers, d_model=d_model,
                                   n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout,
-                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var, 
+                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var,
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
-            self.model_res = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride, 
+                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
+            self.model_res = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride,
                                   max_seq_len=max_seq_len, n_layers=n_layers, d_model=d_model,
                                   n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout,
-                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var, 
+                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var,
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
+                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
         else:
-            self.model = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride, 
+            self.model = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride,
                                   max_seq_len=max_seq_len, n_layers=n_layers, d_model=d_model,
                                   n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout,
-                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var, 
+                                  dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var,
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
+                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
     
     
     def forward(self, x):           # x: [Batch, Input length, Channel]

--- a/PatchTST_supervised/run_longExp.py
+++ b/PatchTST_supervised/run_longExp.py
@@ -43,6 +43,8 @@ if __name__ == '__main__':
     parser.add_argument('--patch_len', type=int, default=16, help='patch length')
     parser.add_argument('--stride', type=int, default=8, help='stride')
     parser.add_argument('--padding_patch', default='end', help='None: None; end: padding on the end')
+    parser.add_argument('--moe_mode', type=str, default='both', choices=['none', 'value', 'ffn', 'both'],
+                        help='Mixture-of-Experts usage: none, value encoder only, FFN only, or both')
     parser.add_argument('--revin', type=int, default=1, help='RevIN; True 1 False 0')
     parser.add_argument('--affine', type=int, default=0, help='RevIN-affine; True 1 False 0')
     parser.add_argument('--subtract_last', type=int, default=0, help='0: subtract mean; 1: subtract last')
@@ -117,7 +119,7 @@ if __name__ == '__main__':
     if args.is_training:
         for ii in range(args.itr):
             # setting record of experiments
-            setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(
+            setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_moe{}_dt{}_{}_{}'.format(
                 args.model_id,
                 args.model,
                 args.data,
@@ -132,6 +134,7 @@ if __name__ == '__main__':
                 args.d_ff,
                 args.factor,
                 args.embed,
+                args.moe_mode,
                 args.distil,
                 args.des,ii)
 
@@ -149,22 +152,23 @@ if __name__ == '__main__':
             torch.cuda.empty_cache()
     else:
         ii = 0
-        setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(args.model_id,
-                                                                                                    args.model,
-                                                                                                    args.data,
-                                                                                                    args.features,
-                                                                                                    args.seq_len,
-                                                                                                    args.label_len,
-                                                                                                    args.pred_len,
-                                                                                                    args.d_model,
-                                                                                                    args.n_heads,
-                                                                                                    args.e_layers,
-                                                                                                    args.d_layers,
-                                                                                                    args.d_ff,
-                                                                                                    args.factor,
-                                                                                                    args.embed,
-                                                                                                    args.distil,
-                                                                                                    args.des, ii)
+        setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_moe{}_dt{}_{}_{}'.format(args.model_id,
+                                                                                                           args.model,
+                                                                                                           args.data,
+                                                                                                           args.features,
+                                                                                                           args.seq_len,
+                                                                                                           args.label_len,
+                                                                                                           args.pred_len,
+                                                                                                           args.d_model,
+                                                                                                           args.n_heads,
+                                                                                                           args.e_layers,
+                                                                                                           args.d_layers,
+                                                                                                           args.d_ff,
+                                                                                                           args.factor,
+                                                                                                           args.embed,
+                                                                                                           args.moe_mode,
+                                                                                                           args.distil,
+                                                                                                           args.des, ii)
 
         exp = Exp(args)  # set experiments
         print('>>>>>>>testing : {}<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<'.format(setting))


### PR DESCRIPTION
## Summary
- add configurable helpers to enable or disable MoE in the value encoder and encoder feed-forward network
- expose a `moe_mode` CLI option and propagate resolved settings through model construction with clear logging
- include the selected MoE mode in experiment naming for checkpoints and logs

## Testing
- Not run (torch not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d56f90b2483239719042807055474)