### PR TITLE
Simplify PatchTST by removing MoE and using MSELoss

### DIFF
--- a/PatchTST_supervised/exp/exp_main.py
+++ b/PatchTST_supervised/exp/exp_main.py
@@ -22,7 +22,6 @@ warnings.filterwarnings('ignore')
 class Exp_Main(Exp_Basic):
     def __init__(self, args):
         super(Exp_Main, self).__init__(args)
-        self.aux_weight = getattr(args, 'aux_weight', 0.01)
 
     def _build_model(self):
         model_dict = {
@@ -49,7 +48,7 @@ class Exp_Main(Exp_Basic):
         return model_optim
 
     def _select_criterion(self):
-        criterion = nn.HuberLoss()
+        criterion = nn.MSELoss()
         return criterion
 
     def vali(self, vali_data, vali_loader, criterion):
@@ -78,19 +77,16 @@ class Exp_Main(Exp_Basic):
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                             else:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
-                            aux_loss = 0.
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                         outputs = self.model(batch_x)
                         if isinstance(outputs, tuple):
                             outputs = outputs[0]
-                        aux_loss = 0.
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
-                        aux_loss = 0.
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
@@ -155,9 +151,8 @@ class Exp_Main(Exp_Basic):
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
-                            aux_loss = 0.
                             if isinstance(outputs, tuple):
-                                outputs, aux_loss = outputs
+                                outputs = outputs[0]
                         else:
                             if self.args.output_attention:
                                 outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
@@ -167,25 +162,23 @@ class Exp_Main(Exp_Basic):
                         f_dim = -1 if self.args.features == 'MS' else 0
                         outputs = outputs[:, -self.args.pred_len:, f_dim:]
                         batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                        loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
+                        loss = criterion(outputs, batch_y)
                         train_loss.append(loss.item())
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
                             outputs = self.model(batch_x)
-                            aux_loss = 0.
                             if isinstance(outputs, tuple):
-                                outputs, aux_loss = outputs
+                                outputs = outputs[0]
                     else:
                         if self.args.output_attention:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
                         else:
                             outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark, batch_y)
-                        aux_loss = 0.
                     # print(outputs.shape,batch_y.shape)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     outputs = outputs[:, -self.args.pred_len:, f_dim:]
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
-                    loss = criterion(outputs, batch_y) + self.aux_weight * aux_loss
+                    loss = criterion(outputs, batch_y)
                     train_loss.append(loss.item())
 
                 if (i + 1) % 100 == 0:

--- a/PatchTST_supervised/layers/PatchTST_backbone.py
+++ b/PatchTST_supervised/layers/PatchTST_backbone.py
@@ -20,8 +20,7 @@ class PatchTST_backbone(nn.Module):
                  padding_var:Optional[int]=None, attn_mask:Optional[Tensor]=None, res_attention:bool=True, pre_norm:bool=False, store_attn:bool=False,
                  pe:str='zeros', learn_pe:bool=True, fc_dropout:float=0., head_dropout = 0, padding_patch = None,
                  pretrain_head:bool=False, head_type = 'flatten', individual = False, revin = True, affine = True, subtract_last = False,
-                 verbose:bool=False, use_value_moe: bool = True, use_ffn_moe: bool = True,
-                 value_moe_experts: int = 4, ffn_moe_experts: int = 4, **kwargs):
+                 verbose:bool=False, **kwargs):
         
         super().__init__()
         
@@ -43,8 +42,7 @@ class PatchTST_backbone(nn.Module):
                                 n_layers=n_layers, d_model=d_model, n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff,
                                 attn_dropout=attn_dropout, dropout=dropout, act=act, key_padding_mask=key_padding_mask, padding_var=padding_var,
                                 attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
-                                pe=pe, learn_pe=learn_pe, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe,
-                                value_moe_experts=value_moe_experts, ffn_moe_experts=ffn_moe_experts, **kwargs)
+                                pe=pe, learn_pe=learn_pe, verbose=verbose, **kwargs)
 
         # Head
         self.head_nf = d_model * patch_num
@@ -73,7 +71,7 @@ class PatchTST_backbone(nn.Module):
         z = z.permute(0,1,3,2)                                                              # z: [bs x nvars x patch_len x patch_num]
         
         # model
-        z, aux_loss = self.backbone(z)                                                      # z: [bs x nvars x d_model x patch_num]
+        z = self.backbone(z)                                                                # z: [bs x nvars x d_model x patch_num]
         z = self.head(z)                                                                    # z: [bs x nvars x target_window]
         
         # denorm
@@ -81,7 +79,7 @@ class PatchTST_backbone(nn.Module):
             z = z.permute(0,2,1)
             z = self.revin_layer(z, 'denorm')
             z = z.permute(0,2,1)
-        return z, aux_loss
+        return z
     
     def create_pretrain_head(self, head_nf, vars, dropout):
         return nn.Sequential(nn.Dropout(dropout),
@@ -124,77 +122,8 @@ class Flatten_Head(nn.Module):
             x = self.dropout(x)
         return x
 
-
-
-class SwitchLinear(nn.Module):
-    """Switch-style linear layer with mixture of experts."""
-    def __init__(self, in_features, out_features, n_experts: int = 4):
-        super().__init__()
-        self.n_experts = n_experts
-        self.experts = nn.ModuleList([nn.Linear(in_features, out_features) for _ in range(n_experts)])
-        self.gate = nn.Linear(in_features, n_experts)
-
-    def forward(self, x):
-        gate_logits = self.gate(x)
-        gate = F.softmax(gate_logits, dim=-1)
-        top1 = gate.argmax(dim=-1)
-        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
-        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
-        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
-        meangate = gate.mean(dim=tuple(range(gate.dim() - 1)))
-        aux_loss = (meangate * self.n_experts).pow(2).mean()
-        return out, aux_loss
-
-
-class LinearValueEncoder(nn.Module):
-    """Standard linear projection used when value-side MoE is disabled."""
-
-    def __init__(self, in_features, out_features):
-        super().__init__()
-        self.linear = nn.Linear(in_features, out_features)
-
-    def forward(self, x):
-        out = self.linear(x)
-        aux_loss = torch.zeros((), device=x.device, dtype=x.dtype)
-        return out, aux_loss
-
-
-def build_value_encoder(use_value_moe: bool, in_features: int, out_features: int, n_experts: int = 4):
-    """Factory that builds either SwitchLinear or a plain Linear layer."""
-    if use_value_moe:
-        return SwitchLinear(in_features, out_features, n_experts=n_experts)
-    return LinearValueEncoder(in_features, out_features)
-
-
-class SwitchFeedForward(nn.Module):
-    """MoE feed-forward layer for Switch Transformer."""
-    def __init__(self, d_model, d_ff, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
-        super().__init__()
-        self.n_experts = n_experts
-        self.experts = nn.ModuleList([
-            nn.Sequential(
-                nn.Linear(d_model, d_ff),
-                get_activation_fn(activation),
-                nn.Dropout(dropout),
-                nn.Linear(d_ff, d_model)
-            ) for _ in range(n_experts)
-        ])
-        self.gate = nn.Linear(d_model, n_experts)
-
-    def forward(self, x):
-        gate_logits = self.gate(x)
-        gate = F.softmax(gate_logits, dim=-1)
-        top1 = gate.argmax(dim=-1)
-        one_hot = F.one_hot(top1, self.n_experts).to(x.dtype)
-        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=-1)
-        out = (expert_outs * one_hot.unsqueeze(-2)).sum(-1)
-        meangate = gate.mean(dim=(0, 1))
-        aux_loss = (meangate * self.n_experts).pow(2).mean()
-        return out, aux_loss
-
-
-class StandardFeedForward(nn.Module):
-    """Standard position-wise feed-forward network used when MoE is disabled."""
+class PositionwiseFeedForward(nn.Module):
+    """Standard position-wise feed-forward network."""
 
     def __init__(self, d_model, d_ff, dropout: float = 0., activation: str = "gelu"):
         super().__init__()
@@ -207,16 +136,7 @@ class StandardFeedForward(nn.Module):
         )
 
     def forward(self, x):
-        out = self.net(x)
-        aux_loss = torch.zeros((), device=x.device, dtype=x.dtype)
-        return out, aux_loss
-
-
-def build_ffn_layer(use_ffn_moe: bool, d_model: int, d_ff: int, n_experts: int = 4, dropout: float = 0., activation: str = "gelu"):
-    """Factory that builds either SwitchFeedForward or a standard FFN."""
-    if use_ffn_moe:
-        return SwitchFeedForward(d_model, d_ff, n_experts=n_experts, dropout=dropout, activation=activation)
-    return StandardFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
+        return self.net(x)
 
 
 class TSTiEncoder(nn.Module):  #i means channel-independent
@@ -224,8 +144,7 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
                  n_layers=3, d_model=128, n_heads=16, d_k=None, d_v=None,
                  d_ff=256, norm='BatchNorm', attn_dropout=0., dropout=0., act="gelu", store_attn=False,
                  key_padding_mask='auto', padding_var=None, attn_mask=None, res_attention=True, pre_norm=False,
-                 pe='zeros', learn_pe=True, verbose=False, use_value_moe: bool = True, use_ffn_moe: bool = True,
-                 value_moe_experts: int = 4, ffn_moe_experts: int = 4, **kwargs):
+                 pe='zeros', learn_pe=True, verbose=False, **kwargs):
         
         
         super().__init__()
@@ -235,7 +154,7 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
 
         # Input encoding
         q_len = patch_num
-        self.W_P = build_value_encoder(use_value_moe, patch_len, d_model, n_experts=value_moe_experts)
+        self.W_P = nn.Linear(patch_len, d_model)
         self.seq_len = q_len
 
         # Positional encoding
@@ -247,7 +166,7 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         # Encoder
         self.encoder = TSTEncoder(q_len, d_model, n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout, dropout=dropout,
                                    pre_norm=pre_norm, activation=act, res_attention=res_attention, n_layers=n_layers,
-                                   store_attn=store_attn, use_ffn_moe=use_ffn_moe, ffn_moe_experts=ffn_moe_experts)
+                                   store_attn=store_attn)
 
         
     def forward(self, x) -> Tensor:                                              # x: [bs x nvars x patch_len x patch_num]
@@ -255,17 +174,17 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         n_vars = x.shape[1]
         # Input encoding
         x = x.permute(0,1,3,2)                                                   # x: [bs x nvars x patch_num x patch_len]
-        x, aux1 = self.W_P(x)                                                    # x: [bs x nvars x patch_num x d_model]
+        x = self.W_P(x)                                                          # x: [bs x nvars x patch_num x d_model]
 
         u = torch.reshape(x, (x.shape[0]*x.shape[1],x.shape[2],x.shape[3]))      # u: [bs * nvars x patch_num x d_model]
         u = self.dropout(u + self.W_pos)                                         # u: [bs * nvars x patch_num x d_model]
 
         # Encoder
-        z, aux2 = self.encoder(u)                                                # z: [bs * nvars x patch_num x d_model]
+        z = self.encoder(u)                                                      # z: [bs * nvars x patch_num x d_model]
         z = torch.reshape(z, (-1,n_vars,z.shape[-2],z.shape[-1]))                # z: [bs x nvars x patch_num x d_model]
         z = z.permute(0,1,3,2)                                                   # z: [bs x nvars x d_model x patch_num]
 
-        return z, aux1 + aux2
+        return z
             
             
     
@@ -273,38 +192,32 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
 class TSTEncoder(nn.Module):
     def __init__(self, q_len, d_model, n_heads, d_k=None, d_v=None, d_ff=None,
                         norm='BatchNorm', attn_dropout=0., dropout=0., activation='gelu',
-                        res_attention=False, n_layers=1, pre_norm=False, store_attn=False,
-                        use_ffn_moe: bool = True, ffn_moe_experts: int = 4):
+                        res_attention=False, n_layers=1, pre_norm=False, store_attn=False):
         super().__init__()
 
         self.layers = nn.ModuleList([TSTEncoderLayer(q_len, d_model, n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm,
                                                       attn_dropout=attn_dropout, dropout=dropout,
                                                       activation=activation, res_attention=res_attention,
-                                                      pre_norm=pre_norm, store_attn=store_attn,
-                                                      use_ffn_moe=use_ffn_moe, ffn_moe_experts=ffn_moe_experts) for i in range(n_layers)])
+                                                      pre_norm=pre_norm, store_attn=store_attn) for i in range(n_layers)])
         self.res_attention = res_attention
 
     def forward(self, src:Tensor, key_padding_mask:Optional[Tensor]=None, attn_mask:Optional[Tensor]=None):
         output = src
         scores = None
-        aux_loss = 0.0
         if self.res_attention:
             for mod in self.layers:
-                output, scores, l_aux = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-                aux_loss = aux_loss + l_aux
-            return output, aux_loss
+                output, scores = mod(output, prev=scores, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+            return output
         else:
             for mod in self.layers:
-                output, l_aux = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
-                aux_loss = aux_loss + l_aux
-            return output, aux_loss
+                output = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+            return output
 
 
 
 class TSTEncoderLayer(nn.Module):
     def __init__(self, q_len, d_model, n_heads, d_k=None, d_v=None, d_ff=256, store_attn=False,
-                 norm='BatchNorm', attn_dropout=0, dropout=0., bias=True, activation="gelu", res_attention=False, pre_norm=False,
-                 use_ffn_moe: bool = True, ffn_moe_experts: int = 4):
+                 norm='BatchNorm', attn_dropout=0, dropout=0., bias=True, activation="gelu", res_attention=False, pre_norm=False):
         super().__init__()
         assert not d_model%n_heads, f"d_model ({d_model}) must be divisible by n_heads ({n_heads})"
         d_k = d_model // n_heads if d_k is None else d_k
@@ -321,8 +234,8 @@ class TSTEncoderLayer(nn.Module):
         else:
             self.norm_attn = nn.LayerNorm(d_model)
 
-        # Position-wise Feed-Forward replaced with MoE
-        self.ff = build_ffn_layer(use_ffn_moe, d_model, d_ff, n_experts=ffn_moe_experts, dropout=dropout, activation=activation)
+        # Position-wise Feed-Forward
+        self.ff = PositionwiseFeedForward(d_model, d_ff, dropout=dropout, activation=activation)
 
         # Add & Norm
         self.dropout_ffn = nn.Dropout(dropout)
@@ -356,16 +269,16 @@ class TSTEncoderLayer(nn.Module):
         if self.pre_norm:
             src = self.norm_ffn(src)
         ## Position-wise Feed-Forward
-        src2, aux_loss = self.ff(src)
+        src2 = self.ff(src)
         ## Add & Norm
         src = src + self.dropout_ffn(src2) # Add: residual connection with residual dropout
         if not self.pre_norm:
             src = self.norm_ffn(src)
 
         if self.res_attention:
-            return src, scores, aux_loss
+            return src, scores
         else:
-            return src, aux_loss
+            return src
 
 
 

--- a/PatchTST_supervised/models/PatchTST.py
+++ b/PatchTST_supervised/models/PatchTST.py
@@ -45,29 +45,6 @@ class Model(nn.Module):
         decomposition = configs.decomposition
         kernel_size = configs.kernel_size
 
-        moe_mode = getattr(configs, 'moe_mode', None)
-        use_value_moe_arg = getattr(configs, 'use_value_moe', None)
-        use_ffn_moe_arg = getattr(configs, 'use_ffn_moe', None)
-
-        if moe_mode is None:
-            use_value_moe = True if use_value_moe_arg is None else bool(use_value_moe_arg)
-            use_ffn_moe = True if use_ffn_moe_arg is None else bool(use_ffn_moe_arg)
-            if use_value_moe and use_ffn_moe:
-                moe_mode = 'both'
-            elif use_value_moe and not use_ffn_moe:
-                moe_mode = 'value'
-            elif not use_value_moe and use_ffn_moe:
-                moe_mode = 'ffn'
-            else:
-                moe_mode = 'none'
-        else:
-            moe_mode = moe_mode.lower()
-            use_value_moe = moe_mode in ['value', 'both']
-            use_ffn_moe = moe_mode in ['ffn', 'both']
-
-        print(f"MoE config: moe_mode={moe_mode}, use_value_moe={use_value_moe}, use_ffn_moe={use_ffn_moe}")
-        
-        
         # model
         self.decomposition = decomposition
         if self.decomposition:
@@ -79,7 +56,7 @@ class Model(nn.Module):
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
+                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
             self.model_res = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride,
                                   max_seq_len=max_seq_len, n_layers=n_layers, d_model=d_model,
                                   n_heads=n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout,
@@ -87,7 +64,7 @@ class Model(nn.Module):
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
+                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
         else:
             self.model = PatchTST_backbone(c_in=c_in, context_window = context_window, target_window=target_window, patch_len=patch_len, stride=stride,
                                   max_seq_len=max_seq_len, n_layers=n_layers, d_model=d_model,
@@ -96,20 +73,20 @@ class Model(nn.Module):
                                   attn_mask=attn_mask, res_attention=res_attention, pre_norm=pre_norm, store_attn=store_attn,
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
-                                  subtract_last=subtract_last, verbose=verbose, use_value_moe=use_value_moe, use_ffn_moe=use_ffn_moe, **kwargs)
+                                  subtract_last=subtract_last, verbose=verbose, **kwargs)
     
     
     def forward(self, x):           # x: [Batch, Input length, Channel]
         if self.decomposition:
             res_init, trend_init = self.decomp_module(x)
             res_init, trend_init = res_init.permute(0,2,1), trend_init.permute(0,2,1)  # x: [Batch, Channel, Input length]
-            res, aux1 = self.model_res(res_init)
-            trend, aux2 = self.model_trend(trend_init)
+            res = self.model_res(res_init)
+            trend = self.model_trend(trend_init)
             x = res + trend
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
-            return x, aux1 + aux2
+            return x
         else:
             x = x.permute(0,2,1)    # x: [Batch, Channel, Input length]
-            x, aux = self.model(x)
+            x = self.model(x)
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
-            return x, aux
+            return x

--- a/PatchTST_supervised/run_longExp.py
+++ b/PatchTST_supervised/run_longExp.py
@@ -43,8 +43,6 @@ if __name__ == '__main__':
     parser.add_argument('--patch_len', type=int, default=16, help='patch length')
     parser.add_argument('--stride', type=int, default=8, help='stride')
     parser.add_argument('--padding_patch', default='end', help='None: None; end: padding on the end')
-    parser.add_argument('--moe_mode', type=str, default='both', choices=['none', 'value', 'ffn', 'both'],
-                        help='Mixture-of-Experts usage: none, value encoder only, FFN only, or both')
     parser.add_argument('--revin', type=int, default=1, help='RevIN; True 1 False 0')
     parser.add_argument('--affine', type=int, default=0, help='RevIN-affine; True 1 False 0')
     parser.add_argument('--subtract_last', type=int, default=0, help='0: subtract mean; 1: subtract last')
@@ -119,7 +117,7 @@ if __name__ == '__main__':
     if args.is_training:
         for ii in range(args.itr):
             # setting record of experiments
-            setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_moe{}_dt{}_{}_{}'.format(
+            setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(
                 args.model_id,
                 args.model,
                 args.data,
@@ -134,7 +132,6 @@ if __name__ == '__main__':
                 args.d_ff,
                 args.factor,
                 args.embed,
-                args.moe_mode,
                 args.distil,
                 args.des,ii)
 
@@ -152,23 +149,22 @@ if __name__ == '__main__':
             torch.cuda.empty_cache()
     else:
         ii = 0
-        setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_moe{}_dt{}_{}_{}'.format(args.model_id,
-                                                                                                           args.model,
-                                                                                                           args.data,
-                                                                                                           args.features,
-                                                                                                           args.seq_len,
-                                                                                                           args.label_len,
-                                                                                                           args.pred_len,
-                                                                                                           args.d_model,
-                                                                                                           args.n_heads,
-                                                                                                           args.e_layers,
-                                                                                                           args.d_layers,
-                                                                                                           args.d_ff,
-                                                                                                           args.factor,
-                                                                                                           args.embed,
-                                                                                                           args.moe_mode,
-                                                                                                           args.distil,
-                                                                                                           args.des, ii)
+        setting = '{}_{}_{}_ft{}_sl{}_ll{}_pl{}_dm{}_nh{}_el{}_dl{}_df{}_fc{}_eb{}_dt{}_{}_{}'.format(args.model_id,
+                                                                                                       args.model,
+                                                                                                       args.data,
+                                                                                                       args.features,
+                                                                                                       args.seq_len,
+                                                                                                       args.label_len,
+                                                                                                       args.pred_len,
+                                                                                                       args.d_model,
+                                                                                                       args.n_heads,
+                                                                                                       args.e_layers,
+                                                                                                       args.d_layers,
+                                                                                                       args.d_ff,
+                                                                                                       args.factor,
+                                                                                                       args.embed,
+                                                                                                       args.distil,
+                                                                                                       args.des, ii)
 
         exp = Exp(args)  # set experiments
         print('>>>>>>>testing : {}<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<'.format(setting))


### PR DESCRIPTION
## Summary
- remove mixture-of-experts configuration and auxiliary losses from PatchTST model and backbone
- simplify encoder feed-forward/value projections to standard layers
- switch training/validation loss to MSE and drop MoE CLI options from long run script

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694268d748e88323ab6e9170f97475c1)