### PR TITLE
Log gate statistics during training

### DIFF
--- a/PatchTST_supervised/exp/exp_main.py
+++ b/PatchTST_supervised/exp/exp_main.py
@@ -51,6 +51,16 @@ class Exp_Main(Exp_Basic):
         criterion = nn.MSELoss()
         return criterion
 
+    def _extract_output_and_gate(self, outputs):
+        gate_stats = None
+        if isinstance(outputs, tuple) and len(outputs) == 2:
+            maybe_gate = outputs[1]
+            if isinstance(maybe_gate, dict) and {'mean', 'std', 'min', 'max'}.issubset(set(maybe_gate.keys())):
+                outputs, gate_stats = outputs
+            else:
+                outputs = outputs[0]
+        return outputs, gate_stats
+
     def vali(self, vali_data, vali_loader, criterion):
         total_loss = []
         self.model.eval()
@@ -69,24 +79,20 @@ class Exp_Main(Exp_Basic):
                 if self.args.use_amp:
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                         else:
                             if self.args.output_attention:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                             else:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
-                        outputs = self.model(batch_x)
-                        if isinstance(outputs, tuple):
-                            outputs = outputs[0]
+                        outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                     else:
                         if self.args.output_attention:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                         else:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                 f_dim = -1 if self.args.features == 'MS' else 0
                 outputs = outputs[:, -self.args.pred_len:, f_dim:]
                 batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
@@ -147,17 +153,16 @@ class Exp_Main(Exp_Basic):
                 dec_inp = torch.cat([batch_y[:, :self.args.label_len, :], dec_inp], dim=1).float().to(self.device)
 
                 # encoder - decoder
+                gate_stats = None
                 if self.args.use_amp:
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x))
                         else:
                             if self.args.output_attention:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                                outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                             else:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                                outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
 
                         f_dim = -1 if self.args.features == 'MS' else 0
                         outputs = outputs[:, -self.args.pred_len:, f_dim:]
@@ -166,20 +171,21 @@ class Exp_Main(Exp_Basic):
                         train_loss.append(loss.item())
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x))
                     else:
                         if self.args.output_attention:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                            outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                         else:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark, batch_y)
+                            outputs, gate_stats = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark, batch_y))
                     # print(outputs.shape,batch_y.shape)
                     f_dim = -1 if self.args.features == 'MS' else 0
                     outputs = outputs[:, -self.args.pred_len:, f_dim:]
                     batch_y = batch_y[:, -self.args.pred_len:, f_dim:].to(self.device)
                     loss = criterion(outputs, batch_y)
                     train_loss.append(loss.item())
+
+                if gate_stats is not None and (i == 0 or (i + 1) % 100 == 0):
+                    print("\tgate stats - mean: {mean:.4f} std: {std:.4f} min: {min:.4f} max: {max:.4f}".format(**gate_stats))
 
                 if (i + 1) % 100 == 0:
                     print("\titers: {0}, epoch: {1} | loss: {2:.7f}".format(i + 1, epoch + 1, loss.item()))
@@ -253,25 +259,21 @@ class Exp_Main(Exp_Basic):
                 if self.args.use_amp:
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                         else:
                             if self.args.output_attention:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                             else:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                     else:
                         if self.args.output_attention:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
 
                         else:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
 
                 f_dim = -1 if self.args.features == 'MS' else 0
                 # print(outputs.shape,batch_y.shape)
@@ -348,24 +350,20 @@ class Exp_Main(Exp_Basic):
                 if self.args.use_amp:
                     with torch.cuda.amp.autocast():
                         if 'Linear' in self.args.model or 'TST' in self.args.model:
-                            outputs = self.model(batch_x)
-                            if isinstance(outputs, tuple):
-                                outputs = outputs[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                         else:
                             if self.args.output_attention:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                             else:
-                                outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                                outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                 else:
                     if 'Linear' in self.args.model or 'TST' in self.args.model:
-                        outputs = self.model(batch_x)
-                        if isinstance(outputs, tuple):
-                            outputs = outputs[0]
+                        outputs, _ = self._extract_output_and_gate(self.model(batch_x))
                     else:
                         if self.args.output_attention:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)[0]
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                         else:
-                            outputs = self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark)
+                            outputs, _ = self._extract_output_and_gate(self.model(batch_x, batch_x_mark, dec_inp, batch_y_mark))
                 pred = outputs.detach().cpu().numpy()  # .squeeze()
                 preds.append(pred)
 

--- a/PatchTST_supervised/layers/PatchTST_backbone.py
+++ b/PatchTST_supervised/layers/PatchTST_backbone.py
@@ -167,6 +167,8 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         self.encoder = TSTEncoder(q_len, d_model, n_heads, d_k=d_k, d_v=d_v, d_ff=d_ff, norm=norm, attn_dropout=attn_dropout, dropout=dropout,
                                    pre_norm=pre_norm, activation=act, res_attention=res_attention, n_layers=n_layers,
                                    store_attn=store_attn, attn_gate_mode=attn_gate_mode, attn_gate_init=attn_gate_init)
+        self.latest_gate_tokens = []
+        self.latest_gate_stats = None
 
         
     def forward(self, x) -> Tensor:                                              # x: [bs x nvars x patch_len x patch_num]
@@ -184,7 +186,22 @@ class TSTiEncoder(nn.Module):  #i means channel-independent
         z = torch.reshape(z, (-1,n_vars,z.shape[-2],z.shape[-1]))                # z: [bs x nvars x patch_num x d_model]
         z = z.permute(0,1,3,2)                                                   # z: [bs x nvars x d_model x patch_num]
 
+        self.latest_gate_tokens = self.encoder.get_gate_tokens()
+        if self.latest_gate_tokens:
+            flat_gates = torch.cat([g.flatten() for g in self.latest_gate_tokens])
+            self.latest_gate_stats = {
+                'mean': flat_gates.mean().item(),
+                'std': flat_gates.std().item(),
+                'min': flat_gates.min().item(),
+                'max': flat_gates.max().item(),
+            }
+        else:
+            self.latest_gate_stats = None
+
         return z
+
+    def get_gate_statistics(self):
+        return self.latest_gate_stats
             
             
     
@@ -214,6 +231,13 @@ class TSTEncoder(nn.Module):
             for mod in self.layers:
                 output = mod(output, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
             return output
+
+    def get_gate_tokens(self):
+        gate_tokens = []
+        for mod in self.layers:
+            if getattr(mod, 'last_gate_token', None) is not None:
+                gate_tokens.append(mod.last_gate_token)
+        return gate_tokens
 
 
 
@@ -251,6 +275,8 @@ class TSTEncoderLayer(nn.Module):
         self.pre_norm = pre_norm
         self.store_attn = store_attn
         self.attn_gate_mode = attn_gate_mode
+        self.last_gate_token = None
+        self.last_gate_stats = None
 
 
     def forward(self, src:Tensor, prev:Optional[Tensor]=None, key_padding_mask:Optional[Tensor]=None, attn_mask:Optional[Tensor]=None) -> Tensor:
@@ -263,6 +289,8 @@ class TSTEncoderLayer(nn.Module):
             src2, attn, scores, gate_token = self.self_attn(src, src, src, prev, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
         else:
             src2, attn, gate_token = self.self_attn(src, src, src, key_padding_mask=key_padding_mask, attn_mask=attn_mask)
+        self.last_gate_token = self.self_attn.get_gate_token()
+        self.last_gate_stats = self.self_attn.get_gate_stats()
         if self.store_attn:
             self.attn = attn
         ## Add & Norm
@@ -320,6 +348,8 @@ class _MultiheadAttention(nn.Module):
         self.gate_proj = nn.Linear(d_model, 1, bias=True)
         self.gate_proj.weight.data.zero_()
         self.gate_proj.bias.data.fill_(attn_gate_init)
+        self.last_gate_token = None
+        self.last_gate_stats = None
 
 
     def forward(self, Q:Tensor, K:Optional[Tensor]=None, V:Optional[Tensor]=None, prev:Optional[Tensor]=None,
@@ -336,6 +366,16 @@ class _MultiheadAttention(nn.Module):
             gate_token = torch.sigmoid(self.gate_proj(Q))
             gate_broadcast = gate_token.unsqueeze(1)                       # [bs, 1, q_len, 1]
             gate_broadcast_k = gate_token.unsqueeze(1).transpose(-2, -1)   # [bs, 1, 1, q_len]
+            self.last_gate_token = gate_token.detach()
+            self.last_gate_stats = {
+                'mean': self.last_gate_token.mean().item(),
+                'std': self.last_gate_token.std().item(),
+                'min': self.last_gate_token.min().item(),
+                'max': self.last_gate_token.max().item(),
+            }
+        else:
+            self.last_gate_token = None
+            self.last_gate_stats = None
 
         # Linear (+ split in multiple heads)
         q_s = self.W_Q(Q).view(bs, -1, self.n_heads, self.d_k).transpose(1,2)       # q_s    : [bs x n_heads x max_q_len x d_k]
@@ -371,6 +411,12 @@ class _MultiheadAttention(nn.Module):
 
         if self.res_attention: return output, attn_weights, attn_scores, gate_token
         else: return output, attn_weights, gate_token
+
+    def get_gate_token(self):
+        return self.last_gate_token
+
+    def get_gate_stats(self):
+        return self.last_gate_stats
 
 
 class _ScaledDotProductAttention(nn.Module):

--- a/PatchTST_supervised/models/PatchTST.py
+++ b/PatchTST_supervised/models/PatchTST.py
@@ -76,8 +76,8 @@ class Model(nn.Module):
                                   pe=pe, learn_pe=learn_pe, fc_dropout=fc_dropout, head_dropout=head_dropout, padding_patch = padding_patch,
                                   pretrain_head=pretrain_head, head_type=head_type, individual=individual, revin=revin, affine=affine,
                                   subtract_last=subtract_last, verbose=verbose, attn_gate_mode=attn_gate_mode, attn_gate_init=attn_gate_init, **kwargs)
-    
-    
+
+
     def forward(self, x):           # x: [Batch, Input length, Channel]
         if self.decomposition:
             res_init, trend_init = self.decomp_module(x)
@@ -86,9 +86,38 @@ class Model(nn.Module):
             trend = self.model_trend(trend_init)
             x = res + trend
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
+            self.latest_gate_stats = self._collect_gate_statistics()
+            if self.latest_gate_stats is not None:
+                return x, self.latest_gate_stats
             return x
         else:
             x = x.permute(0,2,1)    # x: [Batch, Channel, Input length]
             x = self.model(x)
             x = x.permute(0,2,1)    # x: [Batch, Input length, Channel]
+            self.latest_gate_stats = self._collect_gate_statistics()
+            if self.latest_gate_stats is not None:
+                return x, self.latest_gate_stats
             return x
+
+    def _collect_gate_statistics(self):
+        gate_stats = []
+        if self.decomposition:
+            if hasattr(self, 'model_res') and getattr(self.model_res, 'latest_gate_stats', None) is not None:
+                gate_stats.append(self.model_res.latest_gate_stats)
+            if hasattr(self, 'model_trend') and getattr(self.model_trend, 'latest_gate_stats', None) is not None:
+                gate_stats.append(self.model_trend.latest_gate_stats)
+        else:
+            if hasattr(self, 'model') and getattr(self.model, 'latest_gate_stats', None) is not None:
+                gate_stats.append(self.model.latest_gate_stats)
+
+        if not gate_stats:
+            return None
+
+        mean = np.mean([stat['mean'] for stat in gate_stats])
+        std = np.mean([stat['std'] for stat in gate_stats])
+        min_v = min([stat['min'] for stat in gate_stats])
+        max_v = max([stat['max'] for stat in gate_stats])
+        return {'mean': mean, 'std': std, 'min': min_v, 'max': max_v}
+
+    def get_gate_statistics(self):
+        return getattr(self, 'latest_gate_stats', None)


### PR DESCRIPTION
## Summary
- track attention gate activations and compute statistics in PatchTST components
- expose gate statistics from the model and log them during training to catch collapsed gates

## Testing
- python -m compileall PatchTST_supervised

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436fbb1aa08323b67310fe16f02181)